### PR TITLE
Wait for synthetic transactions to complete when testing ABCI application

### DIFF
--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -5,13 +5,14 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/AccumulateNetwork/accumulated/internal/abci"
 	accapi "github.com/AccumulateNetwork/accumulated/internal/api"
 	"github.com/AccumulateNetwork/accumulated/internal/chain"
 	"github.com/AccumulateNetwork/accumulated/internal/relay"
+	acctesting "github.com/AccumulateNetwork/accumulated/internal/testing"
 	"github.com/AccumulateNetwork/accumulated/types"
 	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
 	"github.com/AccumulateNetwork/accumulated/types/api"
@@ -21,8 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
-	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
-	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	randpkg "golang.org/x/exp/rand"
 )
 
@@ -32,14 +31,14 @@ var fakeTxid = sha256.Sum256([]byte("fake txid"))
 type Tx = transactions.GenTransaction
 
 func TestE2E_Accumulator_AnonToken(t *testing.T) {
-	app := createApp(t)
+	app, client := createApp(t)
 
 	_, sponsor, _ := ed25519.GenerateKey(rand)
 	_, recipient, _ := ed25519.GenerateKey(rand)
 
-	appSendTx(t, app, func(send func(*Tx)) {
+	client.Batch(func(send func(*Tx)) {
 		send(createFakeSyntheticDeposit(t, sponsor, recipient))
-	})
+	}, onErr(t))
 
 	origin := transactions.NewWalletEntry()
 	origin.Nonce = 1
@@ -51,7 +50,7 @@ func TestE2E_Accumulator_AnonToken(t *testing.T) {
 		recipients[i] = transactions.NewWalletEntry()
 	}
 
-	appSendTx(t, app, func(send func(*Tx)) {
+	client.Batch(func(send func(*Tx)) {
 		for i := 0; i < 10; i++ {
 			recipient := recipients[rand.Intn(len(recipients))]
 			output := transactions.Output{Dest: recipient.Addr, Amount: 1000}
@@ -60,20 +59,22 @@ func TestE2E_Accumulator_AnonToken(t *testing.T) {
 			require.NoError(t, err)
 			send(tx)
 		}
-	})
+	}, onErr(t))
+
+	client.Wait()
 
 	t.Log(mustJSON(t, appGetChainState(t, app, origin.Addr+"/dc/ACME")))
 }
 
 func BenchmarkE2E_Accumulator_AnonToken(b *testing.B) {
-	app := createApp(b)
+	_, client := createApp(b)
 
 	_, sponsor, _ := ed25519.GenerateKey(rand)
 	_, recipient, _ := ed25519.GenerateKey(rand)
 
-	appSendTx(b, app, func(send func(*Tx)) {
+	client.Batch(func(send func(*Tx)) {
 		send(createFakeSyntheticDeposit(b, sponsor, recipient))
-	})
+	}, onErr(b))
 
 	origin := transactions.NewWalletEntry()
 	origin.Nonce = 1
@@ -83,7 +84,7 @@ func BenchmarkE2E_Accumulator_AnonToken(b *testing.B) {
 	rwallet := transactions.NewWalletEntry()
 
 	b.ResetTimer()
-	appSendTx(b, app, func(send func(*Tx)) {
+	client.Batch(func(send func(*Tx)) {
 		for i := 0; i < b.N; i++ {
 			output := transactions.Output{Dest: rwallet.Addr, Amount: 1000}
 			exch := transactions.NewTokenSend(origin.Addr, output)
@@ -91,10 +92,10 @@ func BenchmarkE2E_Accumulator_AnonToken(b *testing.B) {
 			require.NoError(b, err)
 			send(tx)
 		}
-	})
+	}, onErr(b))
 }
 
-func createApp(t testing.TB) abcitypes.Application {
+func createApp(t testing.TB) (abcitypes.Application, *acctesting.ABCIApplicationClient) {
 	_, bvcKey, _ := ed25519.GenerateKey(rand)
 
 	appId := sha256.Sum256([]byte("foo bar"))
@@ -102,17 +103,19 @@ func createApp(t testing.TB) abcitypes.Application {
 	err := db.Open("valacc.db", appId[:], true, true)
 	require.NoError(t, err)
 
-	rpcClient, err := rpchttp.New("tcp://foo.bar:123")
-	require.NoError(t, err)
+	appChan := make(chan abcitypes.Application)
+	appClient := acctesting.NewABCIApplicationClient(appChan, nextHeight)
+	defer close(appChan)
 
 	bvc := chain.NewBlockValidator()
-	mgr, err := chain.NewManager(accapi.NewQuery(relay.New(rpcClient)), db, bvcKey, bvc)
+	mgr, err := chain.NewManager(accapi.NewQuery(relay.New(appClient)), db, bvcKey, bvc)
 	require.NoError(t, err)
 
 	app, err := abci.NewAccumulator(db, crypto.Address{}, mgr)
 	require.NoError(t, err)
+	appChan <- app
 
-	return app
+	return app, appClient
 }
 
 func mustJSON(t testing.TB, v interface{}) string {
@@ -174,24 +177,18 @@ func appGetChainState(t testing.TB, app abcitypes.Application, url string) *api.
 }
 
 var lastHeight int64
+var heightMu sync.Mutex
 
-func appSendTx(t testing.TB, app abcitypes.Application, do func(func(*Tx))) {
-	t.Helper()
-
+func nextHeight() int64 {
+	heightMu.Lock()
+	defer heightMu.Unlock()
 	lastHeight++
-	app.BeginBlock(abcitypes.RequestBeginBlock{Header: tmtypes.Header{Height: lastHeight, Time: time.Now()}})
+	return lastHeight
+}
 
-	do(func(gtx *Tx) {
-		tx, err := gtx.Marshal()
+func onErr(t testing.TB) func(error) {
+	return func(err error) {
+		t.Helper()
 		require.NoError(t, err)
-
-		cresp := app.CheckTx(abcitypes.RequestCheckTx{Tx: tx})
-		require.Zero(t, cresp.Code, cresp.Info)
-		dresp := app.DeliverTx(abcitypes.RequestDeliverTx{Tx: tx})
-		require.Zero(t, dresp.Code, dresp.Info)
-	})
-
-	app.EndBlock(abcitypes.RequestEndBlock{})
-
-	app.Commit()
+	}
 }

--- a/internal/testing/app_client.go
+++ b/internal/testing/app_client.go
@@ -1,0 +1,172 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/bytes"
+	rpc "github.com/tendermint/tendermint/rpc/client"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+	"github.com/tendermint/tendermint/types"
+)
+
+type ABCIApplicationClient struct {
+	appWg      *sync.WaitGroup
+	blockMu    *sync.Mutex
+	blockWg    *sync.WaitGroup
+	app        abci.Application
+	nextHeight func() int64
+}
+
+var _ rpc.ABCIClient = (*ABCIApplicationClient)(nil)
+
+func NewABCIApplicationClient(app <-chan abci.Application, nextHeight func() int64) *ABCIApplicationClient {
+	c := new(ABCIApplicationClient)
+	c.appWg = new(sync.WaitGroup)
+	c.blockMu = new(sync.Mutex)
+	c.blockWg = new(sync.WaitGroup)
+	c.nextHeight = nextHeight
+
+	c.appWg.Add(1)
+	go func() {
+		defer c.appWg.Done()
+		c.app = <-app
+	}()
+	return c
+}
+
+func (c *ABCIApplicationClient) App() abci.Application {
+	c.appWg.Wait()
+	return c.app
+}
+
+// Wait until all pending transactions are done
+func (c *ABCIApplicationClient) Wait() {
+	c.blockWg.Wait()
+}
+
+func (c *ABCIApplicationClient) ABCIInfo(context.Context) (*ctypes.ResultABCIInfo, error) {
+	r := c.App().Info(abci.RequestInfo{})
+	return &ctypes.ResultABCIInfo{Response: r}, nil
+}
+
+func (c *ABCIApplicationClient) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*ctypes.ResultABCIQuery, error) {
+	return c.ABCIQueryWithOptions(ctx, path, data, rpc.DefaultABCIQueryOptions)
+}
+
+func (c *ABCIApplicationClient) ABCIQueryWithOptions(ctx context.Context, path string, data bytes.HexBytes, opts rpc.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	r := c.App().Query(abci.RequestQuery{Data: data, Path: path, Height: opts.Height, Prove: opts.Prove})
+	return &ctypes.ResultABCIQuery{Response: r}, nil
+}
+
+func (c *ABCIApplicationClient) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+	// Wait for nothing
+	c.sendTx(ctx, tx)
+	return &ctypes.ResultBroadcastTx{}, nil
+}
+
+func (c *ABCIApplicationClient) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
+	// Wait for CheckTx
+	checkChan, _ := c.sendTx(ctx, tx)
+	cr := <-checkChan
+	return &ctypes.ResultBroadcastTx{
+		Code:         cr.Code,
+		Data:         cr.Data,
+		Log:          cr.Log,
+		Codespace:    cr.Codespace,
+		MempoolError: cr.MempoolError,
+		// TODO Hash
+	}, nil
+}
+
+func (c *ABCIApplicationClient) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTxCommit, error) {
+	checkChan, deliverChan := c.sendTx(ctx, tx)
+	cr := <-checkChan
+	dr := <-deliverChan
+	return &ctypes.ResultBroadcastTxCommit{
+		CheckTx:   cr,
+		DeliverTx: dr,
+		// TODO Hash, Height
+	}, nil
+}
+
+func (c *ABCIApplicationClient) enterBlock() {
+	app := c.App()
+	c.blockWg.Add(1)
+	c.blockMu.Lock()
+	begin := abci.RequestBeginBlock{}
+	begin.Header.Height = c.nextHeight()
+	app.BeginBlock(begin)
+}
+
+func (c *ABCIApplicationClient) exitBlock() {
+	app := c.App()
+	app.EndBlock(abci.RequestEndBlock{})
+
+	// Should commit always happen? Or only on success?
+	app.Commit()
+
+	c.blockWg.Done()
+	c.blockMu.Unlock()
+}
+
+func (c *ABCIApplicationClient) sendTx(ctx context.Context, tx types.Tx) (<-chan abci.ResponseCheckTx, <-chan abci.ResponseDeliverTx) {
+	app := c.App()
+	checkChan := make(chan abci.ResponseCheckTx, 1)
+	deliverChan := make(chan abci.ResponseDeliverTx, 1)
+
+	go func() {
+		defer close(checkChan)
+		defer close(deliverChan)
+
+		// TODO Roll up multiple TXs into one block?
+		c.enterBlock()
+		defer c.exitBlock()
+
+		rc := app.CheckTx(abci.RequestCheckTx{Tx: tx})
+		checkChan <- rc
+		if rc.Code != 0 {
+			fmt.Printf("CheckTx failed: %v\n", rc.Info)
+			return
+		}
+
+		rd := app.DeliverTx(abci.RequestDeliverTx{Tx: tx})
+		deliverChan <- rd
+		if rd.Code != 0 {
+			fmt.Printf("DeliverTx failed: %v\n", rc.Info)
+			return
+		}
+	}()
+
+	return checkChan, deliverChan
+}
+
+func (c *ABCIApplicationClient) Batch(inBlock func(func(*transactions.GenTransaction)), onErr func(error)) {
+	app := c.App()
+
+	c.enterBlock()
+	defer c.exitBlock()
+
+	inBlock(func(gtx *transactions.GenTransaction) {
+		tx, err := gtx.Marshal()
+		if err != nil {
+			onErr(err)
+			return
+		}
+
+		rc := app.CheckTx(abci.RequestCheckTx{Tx: tx})
+		if rc.Code != 0 {
+			fmt.Printf("CheckTx failed: %v\n", rc.Info)
+			return
+		}
+
+		rd := app.DeliverTx(abci.RequestDeliverTx{Tx: tx})
+		if rd.Code != 0 {
+			fmt.Printf("DeliverTx failed: %v\n", rc.Info)
+			return
+		}
+	})
+}


### PR DESCRIPTION
- Adds an RPC ABCI Client that queries an ABCI application directly.
- Updates the ABCI app E2E test to wait for all transactions.