### PR TITLE
Disable JSON RPC test in CI

### DIFF
--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -92,6 +92,10 @@ func TestLoadOnRemote(t *testing.T) {
 }
 
 func TestJsonRpcAnonToken(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("This test is flaky in CI")
+	}
+
 	//make a client, and also spin up the router grpc
 	dir, err := ioutil.TempDir("", "AccRouterTest-")
 	if err != nil {


### PR DESCRIPTION
This test is flaky and is causing failures in CI that do not indicate real bugs