### PR TITLE
Enforce go mod tidiness

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on: [ push, pull_request ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+        id: go
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Go mod tidy
+        run: go mod tidy
+
+      - name: Verify go.mod is tidy
+        run: |
+          if ! git diff --quiet go.mod go.sum ; then
+            echo -e "\033[1;31mGo mod files are not tidy. Please run \`go mod tidy\`.\033[0m"
+            false
+          fi

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AccumulateNetwork/jsonrpc2/v15 v15.0.0-20210802145948-43d2d974a106
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/Factom-Asset-Tokens/factom v0.0.0-20200222022020-d06cbcfe6ece
-	github.com/boltdb/bolt v1.3.1 // indirect
+	github.com/boltdb/bolt v1.3.1
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgraph-io/badger v1.6.2


### PR DESCRIPTION
This PR adds a requirement that developers run `go mod tidy` before merging.