### PR TITLE
chore: move wallet to API in prep for reorg

### DIFF
--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"testing"
 
+	accapi "github.com/AccumulateNetwork/accumulated/internal/api"
 	acctesting "github.com/AccumulateNetwork/accumulated/internal/testing"
 	"github.com/AccumulateNetwork/accumulated/protocol"
 	"github.com/AccumulateNetwork/accumulated/types"
@@ -29,14 +30,14 @@ func (n *fakeNode) anonTokenTest(count int) string {
 	recipient := generateKey()
 	require.NoError(n.t, acctesting.CreateAnonTokenAccount(n.db, recipient, 5e4))
 
-	origin := transactions.NewWalletEntry()
+	origin := accapi.NewWalletEntry()
 	origin.Nonce = 1
 	origin.PrivateKey = recipient.Bytes()
 	origin.Addr = anon.GenerateAcmeAddress(recipient.PubKey().Bytes())
 
 	recipients := make([]*transactions.WalletEntry, 10)
 	for i := range recipients {
-		recipients[i] = transactions.NewWalletEntry()
+		recipients[i] = accapi.NewWalletEntry()
 	}
 
 	n.Batch(func(send func(*Tx)) {
@@ -175,12 +176,12 @@ func BenchmarkE2E_Accumulator_AnonToken(b *testing.B) {
 		send(tx)
 	})
 
-	origin := transactions.NewWalletEntry()
+	origin := accapi.NewWalletEntry()
 	origin.Nonce = 1
 	origin.PrivateKey = recipient.Bytes()
 	origin.Addr = anon.GenerateAcmeAddress(recipient.PubKey().Address())
 
-	rwallet := transactions.NewWalletEntry()
+	rwallet := accapi.NewWalletEntry()
 
 	b.ResetTimer()
 	n.Batch(func(send func(*Tx)) {

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -464,7 +464,7 @@ func (api *API) faucet(_ context.Context, params json.RawMessage) interface{} {
 		return jsonrpc2.NewError(-32802, fmt.Sprintf("Invalid Anonymous ACME address %s: ", destAccount), errors.New("wrong token URL"))
 	}
 
-	wallet := transactions.NewWalletEntry()
+	wallet := NewWalletEntry()
 	fromAccount := types.String(wallet.Addr)
 
 	//use the public key of the bvc to make a sponsor address (this doesn't really matter right now, but need something so Identity of the BVC is good)

--- a/internal/api/wallet.go
+++ b/internal/api/wallet.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"crypto/ed25519"
+
+	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
+	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+)
+
+func NewWalletEntry() *transactions.WalletEntry {
+	wallet := new(transactions.WalletEntry)
+
+	wallet.Nonce = 1 // Put the private key for the origin
+	_, wallet.PrivateKey, _ = ed25519.GenerateKey(nil)
+	wallet.Addr = anon.GenerateAcmeAddress(wallet.PrivateKey[32:]) // Generate the origin address
+
+	return wallet
+}

--- a/internal/testing/load.go
+++ b/internal/testing/load.go
@@ -22,13 +22,13 @@ func Load(query *api.Query, Origin ed25519.PrivateKey, walletCount, txCount int)
 
 	var wallet []*transactions.WalletEntry
 
-	wallet = append(wallet, transactions.NewWalletEntry()) // wallet[0] is where we put 5000 ACME tokens
+	wallet = append(wallet, api.NewWalletEntry())          // wallet[0] is where we put 5000 ACME tokens
 	wallet[0].Nonce = 1                                    // start the nonce at 1
 	wallet[0].PrivateKey = Origin                          // Put the private key for the origin
 	wallet[0].Addr = anon.GenerateAcmeAddress(Origin[32:]) // Generate the origin address
 
 	for i := 0; i < walletCount; i++ { //                            create a 1000 addresses for anonymous token chains
-		wallet = append(wallet, transactions.NewWalletEntry()) // create a new wallet entry
+		wallet = append(wallet, api.NewWalletEntry()) // create a new wallet entry
 	}
 
 	addrCountMap := make(map[string]int)

--- a/types/api/transactions/wallet.go
+++ b/types/api/transactions/wallet.go
@@ -2,8 +2,6 @@ package transactions
 
 import (
 	"crypto/ed25519"
-
-	anon "github.com/AccumulateNetwork/accumulated/types/anonaddress"
 )
 
 type WalletEntry struct {
@@ -24,14 +22,4 @@ func (we *WalletEntry) Sign(message []byte) *ED25519Sig { // sign a message
 
 func (we *WalletEntry) Public() []byte {
 	return we.PrivateKey[32:]
-}
-
-func NewWalletEntry() *WalletEntry {
-	wallet := new(WalletEntry)
-
-	wallet.Nonce = 1 // Put the private key for the origin
-	_, wallet.PrivateKey, _ = ed25519.GenerateKey(nil)
-	wallet.Addr = anon.GenerateAcmeAddress(wallet.PrivateKey[32:]) // Generate the origin address
-
-	return wallet
 }

--- a/types/state/Transaction_test.go
+++ b/types/state/Transaction_test.go
@@ -1,13 +1,15 @@
-package state
+package state_test
 
 import (
 	"bytes"
 	"crypto/sha256"
-	"github.com/AccumulateNetwork/accumulated/types"
-	"github.com/AccumulateNetwork/accumulated/types/api"
 	"testing"
 
+	accapi "github.com/AccumulateNetwork/accumulated/internal/api"
+	"github.com/AccumulateNetwork/accumulated/types"
+	"github.com/AccumulateNetwork/accumulated/types/api"
 	"github.com/AccumulateNetwork/accumulated/types/api/transactions"
+	. "github.com/AccumulateNetwork/accumulated/types/state"
 )
 
 func TestTransactionState(t *testing.T) {
@@ -17,7 +19,7 @@ func TestTransactionState(t *testing.T) {
 
 	var nonce uint64 = 1
 
-	we := transactions.NewWalletEntry()
+	we := accapi.NewWalletEntry()
 	trans := new(transactions.GenTransaction)
 	trans.SigInfo = new(transactions.SignatureInfo)
 	trans.SigInfo.URL = we.Addr


### PR DESCRIPTION
I'm adding state types to `./protocol`. In order to avoid circular dependencies, `NewWalletEntry()` needs to move.