### PR TITLE
Drop 'multi' from multi sig spec

### DIFF
--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -156,14 +156,14 @@ func (n *fakeNode) GetADI(url string) *state.AdiState {
 	return adi
 }
 
-func (n *fakeNode) GetKeyGroup(url string) *protocol.SigSpecGroup {
+func (n *fakeNode) GetSigSpecGroup(url string) *protocol.SigSpecGroup {
 	ssg := new(protocol.SigSpecGroup)
 	n.GetChainAs(url, ssg)
 	return ssg
 }
 
-func (n *fakeNode) GetKeySet(url string) *protocol.MultiSigSpec {
-	mss := new(protocol.MultiSigSpec)
+func (n *fakeNode) GetSigSpec(url string) *protocol.SigSpec {
+	mss := new(protocol.SigSpec)
 	n.GetChainAs(url, mss)
 	return mss
 }

--- a/internal/chain/add_credits.go
+++ b/internal/chain/add_credits.go
@@ -49,10 +49,10 @@ func checkAddCredits(st *state.StateEntry, tx *transactions.GenTransaction) (bod
 		// recipient. Most credit transfers will be within the same ADI, so this
 		// should catch most mistakes early.
 		switch recvChain.Type {
-		case types.ChainTypeAnonTokenAccount, types.ChainTypeMultiSigSpec:
+		case types.ChainTypeAnonTokenAccount, types.ChainTypeSigSpec:
 			// OK
 		default:
-			return nil, nil, nil, nil, fmt.Errorf("invalid recipient: wrong chain type: want %v or %v, got %v", types.ChainTypeAnonTokenAccount, types.ChainTypeMultiSigSpec, recvChain.Type)
+			return nil, nil, nil, nil, fmt.Errorf("invalid recipient: wrong chain type: want %v or %v, got %v", types.ChainTypeAnonTokenAccount, types.ChainTypeSigSpec, recvChain.Type)
 		}
 	} else if errors.Is(err, state.ErrNotFound) {
 		if recvUrl.Routing() == tx.Routing {

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -18,7 +18,7 @@ func NewBlockValidator(query *accapi.Query, db *state.StateDB, key ed25519.Priva
 		TokenIssuance{},
 		TokenAccountCreate{},
 		AddCredits{},
-		CreateMultiSigSpec{},
+		CreateSigSpec{},
 		CreateSigSpecGroup{},
 		AssignSigSpecGroup{},
 		SyntheticCreateChain{},

--- a/internal/chain/create_sig_spec.go
+++ b/internal/chain/create_sig_spec.go
@@ -11,11 +11,11 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types/state"
 )
 
-type CreateMultiSigSpec struct{}
+type CreateSigSpec struct{}
 
-func (CreateMultiSigSpec) Type() types.TxType { return types.TxTypeCreateMultiSigSpec }
+func (CreateSigSpec) Type() types.TxType { return types.TxTypeCreateSigSpec }
 
-func checkCreateMultiSigSpec(st *state.StateEntry, tx *transactions.GenTransaction) (*protocol.CreateMultiSigSpec, *url.URL, error) {
+func checkCreateSigSpec(st *state.StateEntry, tx *transactions.GenTransaction) (*protocol.CreateSigSpec, *url.URL, error) {
 	adiUrl, err := url.Parse(tx.SigInfo.URL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid sponsor URL: %v", err)
@@ -29,14 +29,14 @@ func checkCreateMultiSigSpec(st *state.StateEntry, tx *transactions.GenTransacti
 		return nil, nil, fmt.Errorf("%q is not an ADI", tx.SigInfo.URL)
 	}
 
-	body := new(protocol.CreateMultiSigSpec)
+	body := new(protocol.CreateSigSpec)
 	err = tx.As(body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid payload: %v", err)
 	}
 
-	if len(body.SigSpecs) == 0 {
-		return nil, nil, fmt.Errorf("cannot create empty key set")
+	if len(body.Keys) == 0 {
+		return nil, nil, fmt.Errorf("cannot create empty sig spec")
 	}
 
 	msUrl, err := url.Parse(body.Url)
@@ -51,26 +51,26 @@ func checkCreateMultiSigSpec(st *state.StateEntry, tx *transactions.GenTransacti
 	return body, msUrl, nil
 }
 
-func (CreateMultiSigSpec) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
-	_, _, err := checkCreateMultiSigSpec(st, tx)
+func (CreateSigSpec) CheckTx(st *state.StateEntry, tx *transactions.GenTransaction) error {
+	_, _, err := checkCreateSigSpec(st, tx)
 	return err
 }
 
-func (CreateMultiSigSpec) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
-	body, url, err := checkCreateMultiSigSpec(st, tx)
+func (CreateSigSpec) DeliverTx(st *state.StateEntry, tx *transactions.GenTransaction) (*DeliverTxResult, error) {
+	body, url, err := checkCreateSigSpec(st, tx)
 	if err != nil {
 		return nil, err
 	}
 
-	mss := protocol.NewMultiSigSpec()
+	mss := protocol.NewSigSpec()
 	mss.ChainUrl = types.String(url.String())
 
-	for _, sig := range body.SigSpecs {
-		ss := new(protocol.SigSpec)
+	for _, sig := range body.Keys {
+		ss := new(protocol.KeySpec)
 		ss.HashAlgorithm = sig.HashAlgorithm
 		ss.KeyAlgorithm = sig.KeyAlgorithm
 		ss.PublicKey = sig.PublicKey
-		mss.SigSpecs = append(mss.SigSpecs, ss)
+		mss.Keys = append(mss.Keys, ss)
 	}
 
 	data, err := mss.MarshalBinary()

--- a/internal/chain/identity_create.go
+++ b/internal/chain/identity_create.go
@@ -79,24 +79,24 @@ func (IdentityCreate) DeliverTx(st *state.StateEntry, tx *transactions.GenTransa
 		return nil, fmt.Errorf("ADI URLs cannot contain dots")
 	}
 
-	keySetUrl := identityUrl.JoinPath("keyset0")
-	keyGroupUrl := identityUrl.JoinPath("keygroup0")
+	sigSpecUrl := identityUrl.JoinPath("sigspec0")
+	ssgUrl := identityUrl.JoinPath("ssg0")
 
-	ss := new(protocol.SigSpec)
+	ss := new(protocol.KeySpec)
 	ss.HashAlgorithm = protocol.SHA256
 	ss.KeyAlgorithm = protocol.ED25519
 	ss.PublicKey = ic.PublicKeyHash[:]
 
-	mss := protocol.NewMultiSigSpec()
-	mss.ChainUrl = types.String(keySetUrl.String()) // TODO Allow override
-	mss.SigSpecs = append(mss.SigSpecs, ss)
+	mss := protocol.NewSigSpec()
+	mss.ChainUrl = types.String(sigSpecUrl.String()) // TODO Allow override
+	mss.Keys = append(mss.Keys, ss)
 
 	ssg := protocol.NewSigSpecGroup()
-	ssg.ChainUrl = types.String(keyGroupUrl.String()) // TODO Allow override
-	ssg.MultiSigSpecs = append(ssg.MultiSigSpecs, types.Bytes(keySetUrl.ResourceChain()).AsBytes32())
+	ssg.ChainUrl = types.String(ssgUrl.String()) // TODO Allow override
+	ssg.SigSpecs = append(ssg.SigSpecs, types.Bytes(sigSpecUrl.ResourceChain()).AsBytes32())
 
 	adi := state.NewADI(ic.URL, state.KeyTypeSha256, ic.PublicKeyHash[:])
-	adi.SigSpecId = types.Bytes(keyGroupUrl.ResourceChain()).AsBytes32()
+	adi.SigSpecId = types.Bytes(ssgUrl.ResourceChain()).AsBytes32()
 
 	scc := new(protocol.SyntheticCreateChain)
 	scc.Cause = types.Bytes(tx.TransactionHash()).AsBytes32()

--- a/internal/chain/synthetic_deposit_credits.go
+++ b/internal/chain/synthetic_deposit_credits.go
@@ -29,8 +29,8 @@ func checkSyntheticDepositCredits(st *state.StateEntry, tx *transactions.GenTran
 	case types.ChainTypeAnonTokenAccount:
 		account = new(protocol.AnonTokenAccount)
 
-	case types.ChainTypeMultiSigSpec:
-		account = new(protocol.MultiSigSpec)
+	case types.ChainTypeSigSpec:
+		account = new(protocol.SigSpec)
 
 	default:
 		return nil, nil, fmt.Errorf("cannot deposit tokens into a %v", st.ChainHeader.Type)

--- a/protocol/accounts.go
+++ b/protocol/accounts.go
@@ -6,13 +6,13 @@ import (
 	"github.com/AccumulateNetwork/accumulated/internal/url"
 )
 
-func (ms *MultiSigSpec) CreditCredits(amount uint64) {
+func (ms *SigSpec) CreditCredits(amount uint64) {
 	amt := new(big.Int)
 	amt.SetUint64(amount)
 	ms.CreditBalance.Add(&ms.CreditBalance, amt)
 }
 
-func (ms *MultiSigSpec) DebitCredits(amount uint64) bool {
+func (ms *SigSpec) DebitCredits(amount uint64) bool {
 	amt := new(big.Int)
 	amt.SetUint64(amount)
 	if amt.Cmp(&ms.CreditBalance) > 0 {

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -56,7 +56,7 @@ SyntheticDepositCredits:
   - name: Amount
     type: uvarint
 
-SigSpec:
+KeySpec:
   fields:
   - name: KeyAlgorithm
     type: KeyAlgorithm
@@ -69,7 +69,7 @@ SigSpec:
   - name: Nonce
     type: uvarint
 
-SigSpecParams:
+KeySpecParams:
   fields:
   - name: KeyAlgorithm
     type: KeyAlgorithm
@@ -80,34 +80,34 @@ SigSpecParams:
   - name: PublicKey
     type: bytes
 
-MultiSigSpec:
+SigSpec:
   kind: chain
   fields:
   - name: CreditBalance
     type: bigint
-  - name: SigSpecs
+  - name: Keys
     type: slice
     slice:
-      type: SigSpec
+      type: KeySpec
       pointer: true
       marshal-as: self
 
-CreateMultiSigSpec:
+CreateSigSpec:
   kind: tx
   fields:
   - name: Url
     type: string
-  - name: SigSpecs
+  - name: Keys
     type: slice
     slice:
-      type: SigSpecParams
+      type: KeySpecParams
       pointer: true
       marshal-as: self
 
 SigSpecGroup:
   kind: chain
   fields:
-  - name: MultiSigSpecs
+  - name: SigSpecs
     type: chainSet
 
 CreateSigSpecGroup:
@@ -115,7 +115,7 @@ CreateSigSpecGroup:
   fields:
   - name: Url
     type: string
-  - name: MultiSigSpecs
+  - name: SigSpecs
     type: chainSet
 
 AssignSigSpecGroup:

--- a/types/ChainTypes.go
+++ b/types/ChainTypes.go
@@ -14,7 +14,7 @@ const (
 	ChainTypeTransactionReference // Transaction Reference Chain
 	ChainTypeTransaction          // Transaction Chain
 	ChainTypePendingTransaction   // Pending Chain
-	ChainTypeMultiSigSpec         // Multiple Signature Specification chain
+	ChainTypeSigSpec              // Signature Specification chain
 	ChainTypeSigSpecGroup         // Signature Specification Group chain
 )
 
@@ -31,6 +31,7 @@ var (
 		ChainTypeTransactionReference: "ChainTypeTransactionReference",
 		ChainTypeTransaction:          "ChainTypeTransaction",
 		ChainTypePendingTransaction:   "ChainTypePendingTransaction",
+		ChainTypeSigSpec:              "ChainTypeSigSpec",
 		ChainTypeSigSpecGroup:         "ChainTypeSigSpecGroup",
 	}
 	ChainTypeValue = map[string]ChainType{
@@ -44,6 +45,7 @@ var (
 		"ChainTypeTransactionReference": ChainTypeTransactionReference,
 		"ChainTypeTransaction":          ChainTypeTransaction,
 		"ChainTypePendingTransaction":   ChainTypePendingTransaction,
+		"ChainTypeSigSpec":              ChainTypeSigSpec,
 		"ChainTypeSigSpecGroup":         ChainTypeSigSpecGroup,
 	}
 )

--- a/types/TransactionTypes.go
+++ b/types/TransactionTypes.go
@@ -20,7 +20,6 @@ const (
 	TxTypeMultisigTx
 	TxTypeStateQuery //sends a query to a chain and returns its state information
 	TxTypeCreateSigSpec
-	TxTypeCreateMultiSigSpec
 	TxTypeCreateSigSpecGroup
 	TxTypeAddCredits
 	TxTypeAssignSigSpecGroup
@@ -56,7 +55,7 @@ func init() {
 		TxTypeMultisigTx,
 		TxTypeStateQuery,
 		TxTypeCreateSigSpec,
-		TxTypeCreateMultiSigSpec,
+		TxTypeCreateSigSpec,
 		TxTypeCreateSigSpecGroup,
 		TxTypeAddCredits,
 		TxTypeAssignSigSpecGroup,
@@ -106,8 +105,6 @@ func (t TxType) Name() string {
 		return "stateQuery"
 	case TxTypeCreateSigSpec:
 		return "createSigSpec"
-	case TxTypeCreateMultiSigSpec:
-		return "createMultiSigSpec"
 	case TxTypeCreateSigSpecGroup:
 		return "createSigSpecGroup"
 	case TxTypeAddCredits:


### PR DESCRIPTION
And use 'key' or 'key spec' instead of sig spec for individual keys/hashes/scripts.