### PR TITLE
Rework API TX request for key book support

### DIFF
--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -130,11 +130,11 @@ func CreateTX(sender string, receiver string, amount string) {
 
 		datajson := json.RawMessage(data)
 		params.Tx.Data = &datajson
-		params.Tx.Timestamp = time.Now().Unix()
+		params.Tx.Signer.Nonce = uint64(time.Now().Unix())
 		params.Tx.Signer = &acmeapi.Signer{}
-		params.Tx.Signer.URL = types.String(sender)
+		params.Tx.Sponsor = types.String(sender)
 
-		params.Sig = types.Bytes64{}
+		params.Tx.Sig = types.Bytes64{}
 
 		dataBinary, err := tokentx.MarshalBinary()
 		if err != nil {
@@ -150,7 +150,7 @@ func CreateTX(sender string, receiver string, amount string) {
 		gtx.SigInfo.URL = sender
 		//Provide a nonce, typically this will be queried from identity sig spec and incremented.
 		//since SigGroups are not yet implemented, we will use the unix timestamp for now.
-		gtx.SigInfo.Unused2 = uint64(params.Tx.Timestamp)
+		gtx.SigInfo.Unused2 = params.Tx.Signer.Nonce
 		//The following will be defined in the SigSpec Group for which key to use
 		gtx.SigInfo.MSHeight = 0
 		gtx.SigInfo.PriorityIdx = 0
@@ -160,7 +160,7 @@ func CreateTX(sender string, receiver string, amount string) {
 		if err != nil {
 			return api.NewSubmissionError(err)
 		}
-		params.Sig.FromBytes(ed.GetSignature())
+		params.Tx.Sig.FromBytes(ed.GetSignature())
 		//The public key needs to be used to verify the signature, however,
 		//to pass verification, the validator will hash the key and check the
 		//sig spec group to make sure this key belongs to the identity.

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -358,19 +358,19 @@ func TestJsonRpcAdi(t *testing.T) {
 
 	req.Tx = &api.APIRequestRawTx{}
 	req.Tx.Signer = &api.Signer{}
-	req.Tx.Signer.URL = types.String(adiSponsor)
+	req.Tx.Sponsor = types.String(adiSponsor)
 	copy(req.Tx.Signer.PublicKey[:], kpSponsor.PubKey().Bytes())
-	req.Tx.Timestamp = time.Now().Unix()
+	req.Tx.Signer.Nonce = uint64(time.Now().Unix())
 	adiJson := json.RawMessage(data)
 	req.Tx.Data = &adiJson
 
 	// TODO Why does this sign a ledger? This will fail in GenTransaction.
-	ledger := types.MarshalBinaryLedgerAdiChainPath(*adi.URL.AsString(), *req.Tx.Data, req.Tx.Timestamp)
+	ledger := types.MarshalBinaryLedgerAdiChainPath(*adi.URL.AsString(), *req.Tx.Data, int64(req.Tx.Signer.Nonce))
 	sig, err := kpSponsor.Sign(ledger)
 	if err != nil {
 		t.Fatal(err)
 	}
-	copy(req.Sig[:], sig)
+	copy(req.Tx.Sig[:], sig)
 
 	jsonReq, err := json.Marshal(&req)
 	if err != nil {


### PR DESCRIPTION
Rework API TX request structures to properly support key book based authorization.

- Most fields have been moved from the base request to the TX object.
- `tx.timestamp` has been replaced with `tx.signer.nonce`
- `tx.signer.url` has been replaced with `tx.sponsor`
- `tx.keyPage` has been added
  - `tx.keyPage.index` is the (0-based) index of the key page within the sponsor's key book
  - `tx.keyPage.height` is the height of the key page chain

## Old

```json
{
    "wait": true,
    "sig": "hex blob",
    "tx": {
        "data": { "tx": "payload" },
        "signer": {
            "url": "acc://red-wagon",
            "publicKey": "hex blob"
        },
        "timestamp": 12345
    }
}
```

## New

```json
{
    "wait": true,
    "tx": {
        "sponsor": "acc://red-wagon",
        "data": { "tx": "payload" },
        "signer": {
            "publicKey": "hex blob",
            "nonce": 12345
        },
        "sig": "hex blob",
        "keyPage": {
            "height": 1,
            "index": 2
        }
    }
}
```