### PR TITLE
Remove key and hash algo from key specs

### DIFF
--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -244,9 +244,7 @@ func TestCreateSigSpec(t *testing.T) {
 		cms := new(protocol.CreateSigSpec)
 		cms.Url = "foo/keyset1"
 		cms.Keys = append(cms.Keys, &protocol.KeySpecParams{
-			HashAlgorithm: protocol.Unhashed,
-			KeyAlgorithm:  protocol.ED25519,
-			PublicKey:     testKey.PubKey().Bytes(),
+			PublicKey: testKey.PubKey().Bytes(),
 		})
 
 		tx, err := transactions.New("foo", edSigner(fooKey, 1), cms)
@@ -260,8 +258,6 @@ func TestCreateSigSpec(t *testing.T) {
 	key := spec.Keys[0]
 	require.Equal(t, types.Bytes32{}, spec.SigSpecId)
 	require.Equal(t, uint64(0), key.Nonce)
-	require.Equal(t, protocol.Unhashed, key.HashAlgorithm)
-	require.Equal(t, protocol.ED25519, key.KeyAlgorithm)
 	require.Equal(t, testKey.PubKey().Bytes(), key.PublicKey)
 }
 
@@ -317,9 +313,7 @@ func TestAddSigSpec(t *testing.T) {
 		cms := new(protocol.CreateSigSpec)
 		cms.Url = "foo/sigspec2"
 		cms.Keys = append(cms.Keys, &protocol.KeySpecParams{
-			HashAlgorithm: protocol.Unhashed,
-			KeyAlgorithm:  protocol.ED25519,
-			PublicKey:     testKey2.PubKey().Bytes(),
+			PublicKey: testKey2.PubKey().Bytes(),
 		})
 
 		tx, err := transactions.New("foo/ssg1", edSigner(testKey1, 1), cms)
@@ -333,7 +327,5 @@ func TestAddSigSpec(t *testing.T) {
 	key := spec.Keys[0]
 	require.Equal(t, groupChainId, spec.SigSpecId)
 	require.Equal(t, uint64(0), key.Nonce)
-	require.Equal(t, protocol.Unhashed, key.HashAlgorithm)
-	require.Equal(t, protocol.ED25519, key.KeyAlgorithm)
 	require.Equal(t, testKey2.PubKey().Bytes(), key.PublicKey)
 }

--- a/internal/chain/create_sig_spec.go
+++ b/internal/chain/create_sig_spec.go
@@ -77,8 +77,6 @@ func (CreateSigSpec) DeliverTx(st *StateManager, tx *transactions.GenTransaction
 
 	for _, sig := range body.Keys {
 		ss := new(protocol.KeySpec)
-		ss.HashAlgorithm = sig.HashAlgorithm
-		ss.KeyAlgorithm = sig.KeyAlgorithm
 		ss.PublicKey = sig.PublicKey
 		spec.Keys = append(spec.Keys, ss)
 	}

--- a/internal/chain/executor.go
+++ b/internal/chain/executor.go
@@ -150,11 +150,7 @@ func (m *Executor) check(tx *transactions.GenTransaction) (*StateManager, error)
 	// TODO check height
 
 	for i, sig := range tx.Signature {
-		ks, err := sigSpec.FindKey(sig.PublicKey, protocol.ED25519)
-		if err != nil {
-			return nil, fmt.Errorf("failed to verify signature %d: %v", i, err)
-		}
-
+		ks := sigSpec.FindKey(sig.PublicKey)
 		if ks == nil {
 			return nil, fmt.Errorf("no key spec matches signature %d", i)
 		}

--- a/internal/chain/identity_create.go
+++ b/internal/chain/identity_create.go
@@ -60,8 +60,6 @@ func (IdentityCreate) DeliverTx(st *StateManager, tx *transactions.GenTransactio
 	ssgUrl := identityUrl.JoinPath("ssg0")
 
 	ss := new(protocol.KeySpec)
-	ss.HashAlgorithm = protocol.SHA256
-	ss.KeyAlgorithm = protocol.ED25519
 	ss.PublicKey = body.PublicKeyHash[:]
 
 	mss := protocol.NewSigSpec()

--- a/internal/testing/state.go
+++ b/internal/testing/state.go
@@ -88,8 +88,6 @@ func CreateADI(db *state.StateDB, key ed25519.PrivKey, urlStr types.String) erro
 	ssgUrl := identityUrl.JoinPath("ssg0")
 
 	ss := new(protocol.KeySpec)
-	ss.HashAlgorithm = protocol.SHA256
-	ss.KeyAlgorithm = protocol.ED25519
 	ss.PublicKey = keyHash[:]
 
 	mss := protocol.NewSigSpec()
@@ -150,9 +148,7 @@ func CreateSigSpec(db *state.StateDB, urlStr types.String, keys ...ed25519.PubKe
 	mss.Keys = make([]*protocol.KeySpec, len(keys))
 	for i, key := range keys {
 		mss.Keys[i] = &protocol.KeySpec{
-			HashAlgorithm: protocol.Unhashed,
-			KeyAlgorithm:  protocol.ED25519,
-			PublicKey:     key,
+			PublicKey: key,
 		}
 	}
 

--- a/protocol/hash_algorithm.go
+++ b/protocol/hash_algorithm.go
@@ -56,6 +56,14 @@ func (ha HashAlgorithm) Apply(b []byte) ([]byte, error) {
 	}
 }
 
+func (ha HashAlgorithm) MustApply(b []byte) []byte {
+	b, err := ha.Apply(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
 func (ha HashAlgorithm) BinarySize() int {
 	return 1
 }

--- a/protocol/keys.go
+++ b/protocol/keys.go
@@ -2,24 +2,18 @@ package protocol
 
 import (
 	"bytes"
-	"fmt"
 )
 
-func (ks *SigSpec) FindKey(pubKey []byte, ka KeyAlgorithm) (*KeySpec, error) {
-	for _, key := range ks.Keys {
-		if key.KeyAlgorithm != ka {
-			continue
-		}
-
-		sigKH, err := key.HashAlgorithm.Apply(pubKey)
-		if err != nil {
-			return nil, fmt.Errorf("key spec: %v", err)
-		}
-
-		if bytes.Equal(key.PublicKey, sigKH) {
-			return key, nil
+func (ks *SigSpec) FindKey(pubKey []byte) *KeySpec {
+	// Check each key
+	for _, candidate := range ks.Keys {
+		// Try with each supported hash algorithm
+		for _, ha := range []HashAlgorithm{Unhashed, SHA256, SHA256D} {
+			if bytes.Equal(ha.MustApply(pubKey), candidate.PublicKey) {
+				return candidate
+			}
 		}
 	}
 
-	return nil, nil
+	return nil
 }

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -78,12 +78,6 @@ SyntheticDepositCredits:
 
 KeySpec:
   fields:
-  - name: KeyAlgorithm
-    type: KeyAlgorithm
-    marshal-as: self
-  - name: HashAlgorithm
-    type: HashAlgorithm
-    marshal-as: self
   - name: PublicKey
     type: bytes
   - name: Nonce
@@ -91,12 +85,6 @@ KeySpec:
 
 KeySpecParams:
   fields:
-  - name: KeyAlgorithm
-    type: KeyAlgorithm
-    marshal-as: self
-  - name: HashAlgorithm
-    type: HashAlgorithm
-    marshal-as: self
   - name: PublicKey
     type: bytes
 

--- a/protocol/types_gen.go
+++ b/protocol/types_gen.go
@@ -41,16 +41,12 @@ type CreateSigSpecGroup struct {
 }
 
 type KeySpec struct {
-	KeyAlgorithm  KeyAlgorithm  `json:"keyAlgorithm" form:"keyAlgorithm" query:"keyAlgorithm" validate:"required"`
-	HashAlgorithm HashAlgorithm `json:"hashAlgorithm" form:"hashAlgorithm" query:"hashAlgorithm" validate:"required"`
-	PublicKey     []byte        `json:"publicKey" form:"publicKey" query:"publicKey" validate:"required"`
-	Nonce         uint64        `json:"nonce" form:"nonce" query:"nonce" validate:"required"`
+	PublicKey []byte `json:"publicKey" form:"publicKey" query:"publicKey" validate:"required"`
+	Nonce     uint64 `json:"nonce" form:"nonce" query:"nonce" validate:"required"`
 }
 
 type KeySpecParams struct {
-	KeyAlgorithm  KeyAlgorithm  `json:"keyAlgorithm" form:"keyAlgorithm" query:"keyAlgorithm" validate:"required"`
-	HashAlgorithm HashAlgorithm `json:"hashAlgorithm" form:"hashAlgorithm" query:"hashAlgorithm" validate:"required"`
-	PublicKey     []byte        `json:"publicKey" form:"publicKey" query:"publicKey" validate:"required"`
+	PublicKey []byte `json:"publicKey" form:"publicKey" query:"publicKey" validate:"required"`
 }
 
 type SigSpec struct {
@@ -188,10 +184,6 @@ func (v *CreateSigSpecGroup) BinarySize() int {
 func (v *KeySpec) BinarySize() int {
 	var n int
 
-	n += v.KeyAlgorithm.BinarySize()
-
-	n += v.HashAlgorithm.BinarySize()
-
 	n += bytesBinarySize(v.PublicKey)
 
 	n += uvarintBinarySize(v.Nonce)
@@ -201,10 +193,6 @@ func (v *KeySpec) BinarySize() int {
 
 func (v *KeySpecParams) BinarySize() int {
 	var n int
-
-	n += v.KeyAlgorithm.BinarySize()
-
-	n += v.HashAlgorithm.BinarySize()
 
 	n += bytesBinarySize(v.PublicKey)
 
@@ -382,18 +370,6 @@ func (v *CreateSigSpecGroup) MarshalBinary() ([]byte, error) {
 func (v *KeySpec) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
 
-	if b, err := v.KeyAlgorithm.MarshalBinary(); err != nil {
-		return nil, fmt.Errorf("error encoding KeyAlgorithm: %w", err)
-	} else {
-		buffer.Write(b)
-	}
-
-	if b, err := v.HashAlgorithm.MarshalBinary(); err != nil {
-		return nil, fmt.Errorf("error encoding HashAlgorithm: %w", err)
-	} else {
-		buffer.Write(b)
-	}
-
 	buffer.Write(bytesMarshalBinary(v.PublicKey))
 
 	buffer.Write(uvarintMarshalBinary(v.Nonce))
@@ -403,18 +379,6 @@ func (v *KeySpec) MarshalBinary() ([]byte, error) {
 
 func (v *KeySpecParams) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
-
-	if b, err := v.KeyAlgorithm.MarshalBinary(); err != nil {
-		return nil, fmt.Errorf("error encoding KeyAlgorithm: %w", err)
-	} else {
-		buffer.Write(b)
-	}
-
-	if b, err := v.HashAlgorithm.MarshalBinary(); err != nil {
-		return nil, fmt.Errorf("error encoding HashAlgorithm: %w", err)
-	} else {
-		buffer.Write(b)
-	}
 
 	buffer.Write(bytesMarshalBinary(v.PublicKey))
 
@@ -680,16 +644,6 @@ func (v *CreateSigSpecGroup) UnmarshalBinary(data []byte) error {
 }
 
 func (v *KeySpec) UnmarshalBinary(data []byte) error {
-	if err := v.KeyAlgorithm.UnmarshalBinary(data); err != nil {
-		return fmt.Errorf("error decoding KeyAlgorithm: %w", err)
-	}
-	data = data[v.KeyAlgorithm.BinarySize():]
-
-	if err := v.HashAlgorithm.UnmarshalBinary(data); err != nil {
-		return fmt.Errorf("error decoding HashAlgorithm: %w", err)
-	}
-	data = data[v.HashAlgorithm.BinarySize():]
-
 	if x, err := bytesUnmarshalBinary(data); err != nil {
 		return fmt.Errorf("error decoding PublicKey: %w", err)
 	} else {
@@ -708,16 +662,6 @@ func (v *KeySpec) UnmarshalBinary(data []byte) error {
 }
 
 func (v *KeySpecParams) UnmarshalBinary(data []byte) error {
-	if err := v.KeyAlgorithm.UnmarshalBinary(data); err != nil {
-		return fmt.Errorf("error decoding KeyAlgorithm: %w", err)
-	}
-	data = data[v.KeyAlgorithm.BinarySize():]
-
-	if err := v.HashAlgorithm.UnmarshalBinary(data); err != nil {
-		return fmt.Errorf("error decoding HashAlgorithm: %w", err)
-	}
-	data = data[v.HashAlgorithm.BinarySize():]
-
 	if x, err := bytesUnmarshalBinary(data); err != nil {
 		return fmt.Errorf("error decoding PublicKey: %w", err)
 	} else {


### PR DESCRIPTION
For privacy/security reasons, key specs should not specify key type or hash type.