### PR TITLE
Restrict usable ADI names

### DIFF
--- a/docs/Records.md
+++ b/docs/Records.md
@@ -8,6 +8,7 @@
 - **ADI**
   - Accumulate Digital Identity
   - Most other record types exist as subrecords of an ADI
+  - An ADI name may only include unicode letters and numbers, and dashes
 - **Token Issuer**
   - Defines a type of token and issues those tokens
   - Each token issuer, except those built in to the protocol, belongs to an ADI

--- a/internal/chain/identity_create.go
+++ b/internal/chain/identity_create.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/AccumulateNetwork/accumulated/internal/url"
 	"github.com/AccumulateNetwork/accumulated/protocol"
@@ -26,11 +25,10 @@ func checkIdentityCreate(st *StateManager, tx *transactions.GenTransaction) (*pr
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("invalid URL: %v", err)
 	}
-	if identityUrl.Path != "" {
-		return nil, nil, nil, fmt.Errorf("creating sub-ADIs is not supported")
-	}
-	if strings.ContainsRune(identityUrl.Hostname(), '.') {
-		return nil, nil, nil, fmt.Errorf("ADI URLs cannot contain dots")
+
+	err = protocol.IsValidAdiUrl(identityUrl)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("invalid URL: %v", err)
 	}
 
 	var sponsor state.Chain

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -92,6 +92,23 @@ func (u *URL) String() string {
 	return u.URL().String()
 }
 
+// RawString concatenates all of the URL parts. Does not percent-encode
+// anything. Primarily used for validation.
+func (u *URL) RawString() string {
+	s := "acc://"
+	if u.UserInfo != "" {
+		s += u.UserInfo + "@"
+	}
+	s += u.Authority + u.Path
+	if u.Query != "" {
+		s += "?" + u.Query
+	}
+	if u.Fragment != "" {
+		s += "#" + u.Fragment
+	}
+	return s
+}
+
 // Hostname returns the hostname from the authority component.
 func (u *URL) Hostname() string {
 	s, _ := splitColon(u.Authority)

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,0 +1,57 @@
+package protocol
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	. "github.com/AccumulateNetwork/accumulated/internal/url"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+)
+
+func TestIsValidAdiUrl(t *testing.T) {
+	rand := rand.New(rand.NewSource(0))
+	randHex := func(n int) string {
+		b := make([]byte, n)
+		n, err := rand.Read(b)
+		require.Equal(t, len(b), n)
+		require.NoError(t, err)
+		return hex.EncodeToString(b)
+	}
+
+	good := map[string]string{
+		"Simple":            "foo",
+		"Identity has dash": "foo-bar",
+	}
+	bad := map[string]struct {
+		URL URL
+		err string
+	}{
+		"Invalid UTF-8":           {URL{Authority: "\xF1"}, "not valid UTF-8"},
+		"Has port":                {URL{Authority: "foo:123"}, "identity has a port number"},
+		"Empty identity":          {URL{}, "identity is empty"},
+		"Has path":                {URL{Authority: "foo", Path: "bar"}, "path is not empty"},
+		"Has query":               {URL{Authority: "foo", Query: "bar"}, "query is not empty"},
+		"Has fragment":            {URL{Authority: "foo", Fragment: "bar"}, "fragment is not empty"},
+		"Identity has dot":        {URL{Authority: "foo.bar"}, "identity contains dot(s)"},
+		"Identity has underscore": {URL{Authority: "foo_bar"}, "illegal character '_'"},
+		"Identity has space":      {URL{Authority: "foo bar"}, "illegal character ' '"},
+		"Looks like lite acct lc": {URL{Authority: strings.ToLower(randHex(24))}, "identity could be a lite account key"},
+		"Looks like lite acct uc": {URL{Authority: strings.ToUpper(randHex(24))}, "identity could be a lite account key"},
+	}
+
+	for name, str := range good {
+		t.Run(name, func(t *testing.T) {
+			u, err := Parse(str)
+			require.NoError(t, err)
+			require.NoError(t, IsValidAdiUrl(u))
+		})
+	}
+
+	for name, c := range bad {
+		t.Run(name, func(t *testing.T) {
+			require.EqualError(t, IsValidAdiUrl(&c.URL), c.err)
+		})
+	}
+}


### PR DESCRIPTION
Only allow letters and numbers (as defined by Unicode) and dashes