### PR TITLE
AC-151 default pagination size

### DIFF
--- a/types/api/APIRequests.go
+++ b/types/api/APIRequests.go
@@ -6,6 +6,8 @@ import (
 	"github.com/AccumulateNetwork/accumulated/types"
 )
 
+const DefaultPaginationSize = 20
+
 // API Request Support Structure
 
 // Signer holds the ADI and public key to use to verify the transaction
@@ -50,7 +52,7 @@ type APIRequestURL struct {
 type APIRequestURLPagination struct {
 	APIRequestURL
 	Start int64 `json:"start" validate:"number,gte=0"`
-	Limit int64 `json:"limit" validate:"number,gte=0"`
+	Limit int64 `json:"limit" validate:"number,gt=0"`
 }
 
 // APIDataResponse is used in "get" API method response
@@ -72,4 +74,21 @@ type APIDataResponsePagination struct {
 	Start int64 `json:"start"`
 	Limit int64 `json:"limit"`
 	Total int64 `json:"total"`
+}
+
+// UnmarshalJSON is custom Unmarshal for APIRequestURLPagination
+func (p *APIRequestURLPagination) UnmarshalJSON(data []byte) error {
+
+	type APIRequestURLPaginationAlias APIRequestURLPagination
+
+	test := &APIRequestURLPaginationAlias{
+		Limit: int64(DefaultPaginationSize),
+	}
+	err := json.Unmarshal(data, test)
+	if err != nil {
+		return err
+	}
+
+	*p = APIRequestURLPagination(*test)
+	return nil
 }


### PR DESCRIPTION
This bugfix allows to send `token-account-history` API requests without specifying `start` and `limit` params – when no such params, default pagination size will be applied.