### PR TITLE
Debug faucet test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ cli
 
 /.nodes
 
+debug
+!debug/
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
@@ -33,7 +36,6 @@ engine/overrideversion.go
 *.kate-swp
 *.orig
 *.bak
-debug
 *.txt
 *.log
 .vscode/

--- a/debug/faucet_test.go
+++ b/debug/faucet_test.go
@@ -1,0 +1,47 @@
+package debug_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/AccumulateNetwork/accumulated/internal/api"
+	"github.com/AccumulateNetwork/accumulated/internal/relay"
+	"github.com/AccumulateNetwork/accumulated/internal/url"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugFaucet(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("This is a test made for debugging. It is not intended for use except for as a debugging tool.")
+	}
+
+	// Networks must be in the same order as they are passed to --relay-to in the node configuration
+	clients, err := relay.NewClients("Arches", "AmericanSamoa", "EastXeons")
+	require.NoError(t, err)
+
+	u, err := url.Parse("acc://b5d4ac455c08bedc04a56d8147e9e9c9494c99eb81e9d8c3/ACME")
+	require.NoError(t, err)
+	expectedNetworkId := u.Routing() % uint64(len(clients))
+
+	found := []int{}
+	for i, c := range clients {
+		q := api.NewQuery(relay.New(c))
+		resp, err := q.QueryByUrl(u.String())
+		require.NoError(t, err)
+		if resp.Response.Code != 0 {
+			require.Contains(t, resp.Response.Info, "not found")
+			continue
+		}
+		found = append(found, i)
+	}
+
+	if len(found) == 0 {
+		t.Fatal("The account was not found anywhere. You probably need to use the faucet to create it.")
+	}
+	if len(found) > 1 {
+		t.Fatal("The account was found on multiple BVCs... that is not how it should work.")
+	}
+
+	assert.Equal(t, expectedNetworkId, uint64(found[0]), "The account is supposed to exist on BVC %d but we actually found it on BVC %d", expectedNetworkId, found[0])
+}

--- a/internal/relay/helper.go
+++ b/internal/relay/helper.go
@@ -10,7 +10,7 @@ import (
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
-func NewWith(targetList ...string) (*Relay, error) {
+func NewClients(targetList ...string) ([]Client, error) {
 	clients := []Client{}
 	for _, nameOrIP := range targetList {
 		net := networks.Networks[nameOrIP]
@@ -31,6 +31,15 @@ func NewWith(targetList ...string) (*Relay, error) {
 		}
 		clients = append(clients, client)
 	}
+	return clients, nil
+}
+
+func NewWith(targetList ...string) (*Relay, error) {
+	clients, err := NewClients(targetList...)
+	if err != nil {
+		return nil, err
+	}
+
 	txBouncer := New(clients...)
 	return txBouncer, nil
 }


### PR DESCRIPTION
This is a test for debugging the faucet. It directly queries the Tendermint query interface for each BVC, circumventing the relay, to figure out if the given account exists anywhere. It then compares where it found it to where routing says it should be found.