### PR TITLE
Simplify chain validators

### DIFF
--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -32,11 +32,8 @@ type TxExecutor interface {
 	// Type is the transaction type the executor can execute.
 	Type() types.TxType
 
-	// CheckTx partially validates the transaction.
-	CheckTx(*StateManager, *transactions.GenTransaction) error
-
-	// DeliverTx fully validates and executes the transaction.
-	DeliverTx(*StateManager, *transactions.GenTransaction) error
+	// Validate fully validates and executes the transaction.
+	Validate(*StateManager, *transactions.GenTransaction) error
 }
 
 type creditChain interface {

--- a/internal/chain/create_identity.go
+++ b/internal/chain/create_identity.go
@@ -14,43 +14,29 @@ type CreateIdentity struct{}
 
 func (CreateIdentity) Type() types.TxType { return types.TxTypeCreateIdentity }
 
-func checkCreateIdentity(st *StateManager, tx *transactions.GenTransaction) (*protocol.IdentityCreate, *url.URL, state.Chain, error) {
+func (CreateIdentity) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	// *protocol.IdentityCreate, *url.URL, state.Chain
 	body := new(protocol.IdentityCreate)
 	err := tx.As(body)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid payload: %v", err)
+		return fmt.Errorf("invalid payload: %v", err)
 	}
 
 	identityUrl, err := url.Parse(body.Url)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid URL: %v", err)
+		return fmt.Errorf("invalid URL: %v", err)
 	}
 
 	err = protocol.IsValidAdiUrl(identityUrl)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid URL: %v", err)
+		return fmt.Errorf("invalid URL: %v", err)
 	}
 
-	var sponsor state.Chain
 	switch st.Sponsor.(type) {
 	case *protocol.AnonTokenAccount, *state.AdiState:
 		// OK
 	default:
-		return nil, nil, nil, fmt.Errorf("chain type %d cannot sponsor ADIs", st.Sponsor.Header().Type)
-	}
-
-	return body, identityUrl, sponsor, nil
-}
-
-func (CreateIdentity) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
-	_, _, _, err := checkCreateIdentity(st, tx)
-	return err
-}
-
-func (CreateIdentity) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
-	body, identityUrl, _, err := checkCreateIdentity(st, tx)
-	if err != nil {
-		return err
+		return fmt.Errorf("chain type %d cannot sponsor ADIs", st.Sponsor.Header().Type)
 	}
 
 	var sigSpecUrl, ssgUrl *url.URL

--- a/internal/chain/create_key_book.go
+++ b/internal/chain/create_key_book.go
@@ -14,28 +14,28 @@ type CreateKeyBook struct{}
 
 func (CreateKeyBook) Type() types.TxType { return types.TxTypeCreateKeyBook }
 
-func checkCreateKeyBook(st *StateManager, tx *transactions.GenTransaction) ([]*protocol.SigSpec, *url.URL, error) {
+func (CreateKeyBook) Validate(st *StateManager, tx *transactions.GenTransaction) error {
 	if _, ok := st.Sponsor.(*state.AdiState); !ok {
-		return nil, nil, fmt.Errorf("invalid sponsor: want %v, got %v", types.ChainTypeAdi, st.Sponsor.Header().Type)
+		return fmt.Errorf("invalid sponsor: want %v, got %v", types.ChainTypeAdi, st.Sponsor.Header().Type)
 	}
 
 	body := new(protocol.CreateSigSpecGroup)
 	err := tx.As(body)
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid payload: %v", err)
+		return fmt.Errorf("invalid payload: %v", err)
 	}
 
 	if len(body.SigSpecs) == 0 {
-		return nil, nil, fmt.Errorf("cannot create empty sig spec group")
+		return fmt.Errorf("cannot create empty sig spec group")
 	}
 
 	sgUrl, err := url.Parse(body.Url)
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid target URL: %v", err)
+		return fmt.Errorf("invalid target URL: %v", err)
 	}
 
 	if !sgUrl.Identity().Equal(st.SponsorUrl) {
-		return nil, nil, fmt.Errorf("%q does not belong to %q", sgUrl, st.SponsorUrl)
+		return fmt.Errorf("%q does not belong to %q", sgUrl, st.SponsorUrl)
 	}
 
 	entries := make([]*protocol.SigSpec, len(body.SigSpecs))
@@ -43,38 +43,24 @@ func checkCreateKeyBook(st *StateManager, tx *transactions.GenTransaction) ([]*p
 		entry := new(protocol.SigSpec)
 		err = st.LoadAs(chainId, entry)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch sig spec: %v", err)
+			return fmt.Errorf("failed to fetch sig spec: %v", err)
 		}
 
 		u, err := entry.ParseUrl()
 		if err != nil {
 			// This should not happen. Only valid URLs should be stored.
-			return nil, nil, fmt.Errorf("invalid sig spec state: bad URL: %v", err)
+			return fmt.Errorf("invalid sig spec state: bad URL: %v", err)
 		}
 
 		if !u.Identity().Equal(st.SponsorUrl) {
-			return nil, nil, fmt.Errorf("%q does not belong to %q", u, st.SponsorUrl)
+			return fmt.Errorf("%q does not belong to %q", u, st.SponsorUrl)
 		}
 
 		if (entry.SigSpecId != types.Bytes32{}) {
-			return nil, nil, fmt.Errorf("%q has already been assigned to an SSG", u)
+			return fmt.Errorf("%q has already been assigned to an SSG", u)
 		}
 
 		entries[i] = entry
-	}
-
-	return entries, sgUrl, nil
-}
-
-func (CreateKeyBook) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
-	_, _, err := checkCreateKeyBook(st, tx)
-	return err
-}
-
-func (CreateKeyBook) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
-	entries, url, err := checkCreateKeyBook(st, tx)
-	if err != nil {
-		return err
 	}
 
 	scc := new(protocol.SyntheticCreateChain)
@@ -82,9 +68,9 @@ func (CreateKeyBook) DeliverTx(st *StateManager, tx *transactions.GenTransaction
 	st.Submit(st.SponsorUrl, scc)
 
 	ssg := protocol.NewSigSpecGroup()
-	ssg.ChainUrl = types.String(url.String())
+	ssg.ChainUrl = types.String(sgUrl.String())
 
-	groupChainId := types.Bytes(url.ResourceChain()).AsBytes32()
+	groupChainId := types.Bytes(sgUrl.ResourceChain()).AsBytes32()
 	for _, spec := range entries {
 		u, err := spec.ParseUrl()
 		if err != nil {

--- a/internal/chain/executor.go
+++ b/internal/chain/executor.go
@@ -406,7 +406,7 @@ func (m *Executor) CheckTx(tx *transactions.GenTransaction) error {
 		return fmt.Errorf("unsupported TX type: %v", types.TxType(tx.TransactionType()))
 	}
 
-	return executor.CheckTx(st, tx)
+	return executor.Validate(st, tx)
 }
 
 func (m *Executor) recordTransactionError(txPending *state.PendingTransaction, chainId *types.Bytes32, txid []byte, err error) error {
@@ -476,7 +476,7 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 
 	// Validate
 	// TODO result should return a list of chainId's the transaction touched.
-	err = executor.DeliverTx(st, tx)
+	err = executor.Validate(st, tx)
 	if err != nil {
 		err = fmt.Errorf("rejected by chain: %v", err)
 		return nil, m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), err)

--- a/internal/chain/synthetic_chain_create_test.go
+++ b/internal/chain/synthetic_chain_create_test.go
@@ -37,6 +37,6 @@ func TestSyntheticChainCreate_MultiSlash(t *testing.T) {
 	st, err := NewStateManager(db, tx)
 	require.NoError(t, err)
 
-	err = SyntheticCreateChain{}.DeliverTx(st, tx)
+	err = SyntheticCreateChain{}.Validate(st, tx)
 	require.EqualError(t, err, `ChainTypeTokenAccount cannot contain more than one slash in its URL`)
 }

--- a/internal/chain/synthetic_create_chain.go
+++ b/internal/chain/synthetic_create_chain.go
@@ -127,11 +127,3 @@ func (SyntheticCreateChain) Validate(st *StateManager, tx *transactions.GenTrans
 
 	return nil
 }
-
-func (SyntheticCreateChain) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
-	return SyntheticCreateChain{}.Validate(st, tx)
-}
-
-func (SyntheticCreateChain) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
-	return SyntheticCreateChain{}.Validate(st, tx)
-}

--- a/internal/chain/synthetic_deposit_credits.go
+++ b/internal/chain/synthetic_deposit_credits.go
@@ -12,11 +12,11 @@ type SyntheticDepositCredits struct{}
 
 func (SyntheticDepositCredits) Type() types.TxType { return types.TxTypeSyntheticDepositCredits }
 
-func checkSyntheticDepositCredits(st *StateManager, tx *transactions.GenTransaction) (*protocol.SyntheticDepositCredits, creditChain, error) {
+func (SyntheticDepositCredits) Validate(st *StateManager, tx *transactions.GenTransaction) error {
 	body := new(protocol.SyntheticDepositCredits)
 	err := tx.As(body)
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid payload: %v", err)
+		return fmt.Errorf("invalid payload: %v", err)
 	}
 
 	var account creditChain
@@ -28,24 +28,10 @@ func checkSyntheticDepositCredits(st *StateManager, tx *transactions.GenTransact
 		account = sponsor
 
 	default:
-		return nil, nil, fmt.Errorf("cannot deposit tokens into a %v", st.Sponsor.Header().Type)
+		return fmt.Errorf("cannot deposit tokens into a %v", st.Sponsor.Header().Type)
 	}
 
-	return body, account, nil
-}
-
-func (SyntheticDepositCredits) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
-	_, _, err := checkSyntheticDepositCredits(st, tx)
-	return err
-}
-
-func (SyntheticDepositCredits) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
-	body, chain, err := checkSyntheticDepositCredits(st, tx)
-	if err != nil {
-		return err
-	}
-
-	chain.CreditCredits(body.Amount)
-	st.Update(chain)
+	account.CreditCredits(body.Amount)
+	st.Update(account)
 	return nil
 }

--- a/internal/chain/synthetic_token_deposit.go
+++ b/internal/chain/synthetic_token_deposit.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	"github.com/AccumulateNetwork/accumulate/protocol"
@@ -18,25 +17,26 @@ func (SyntheticTokenDeposit) Type() types.TxType {
 	return types.TxTypeSyntheticDepositTokens
 }
 
-func checkSyntheticTokenDeposit(st *StateManager, tx *transactions.GenTransaction) (*big.Int, tokenChain, *url.URL, error) {
+func (SyntheticTokenDeposit) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	// *big.Int, tokenChain, *url.URL
 	body := new(synthetic.TokenTransactionDeposit)
 	err := tx.As(body)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid payload: %v", err)
+		return fmt.Errorf("invalid payload: %v", err)
 	}
 
 	if body.ToUrl != types.String(tx.SigInfo.URL) {
-		return nil, nil, nil, fmt.Errorf("deposit destination does not match TX sponsor")
+		return fmt.Errorf("deposit destination does not match TX sponsor")
 	}
 
 	accountUrl, err := url.Parse(tx.SigInfo.URL)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid recipient URL: %v", err)
+		return fmt.Errorf("invalid recipient URL: %v", err)
 	}
 
 	tokenUrl, err := url.Parse(*body.TokenUrl.AsString())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid token URL: %v", err)
+		return fmt.Errorf("invalid token URL: %v", err)
 	}
 
 	var account tokenChain
@@ -47,14 +47,14 @@ func checkSyntheticTokenDeposit(st *StateManager, tx *transactions.GenTransactio
 		case *state.TokenAccount:
 			account = sponsor
 		default:
-			return nil, nil, nil, fmt.Errorf("cannot deposit tokens to %v", sponsor.Header().Type)
+			return fmt.Errorf("cannot deposit tokens to %v", sponsor.Header().Type)
 		}
 	} else if keyHash, tok, err := protocol.ParseAnonymousAddress(accountUrl); err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid anonymous token account URL: %v", err)
+		return fmt.Errorf("invalid anonymous token account URL: %v", err)
 	} else if keyHash == nil {
-		return nil, nil, nil, fmt.Errorf("could not find token account")
+		return fmt.Errorf("could not find token account")
 	} else if !tokenUrl.Equal(tok) {
-		return nil, nil, nil, fmt.Errorf("token URL does not match anonymous token account URL")
+		return fmt.Errorf("token URL does not match anonymous token account URL")
 	} else {
 		// Address is anonymous and the account doesn't exist, so create one
 		anon := protocol.NewAnonTokenAccount()
@@ -63,21 +63,7 @@ func checkSyntheticTokenDeposit(st *StateManager, tx *transactions.GenTransactio
 		account = anon
 	}
 
-	return &body.DepositAmount.Int, account, accountUrl, nil
-}
-
-func (SyntheticTokenDeposit) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
-	_, _, _, err := checkSyntheticTokenDeposit(st, tx)
-	return err
-}
-
-func (SyntheticTokenDeposit) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
-	amount, account, accountUrl, err := checkSyntheticTokenDeposit(st, tx)
-	if err != nil {
-		return err
-	}
-
-	if !account.CreditTokens(amount) {
+	if !account.CreditTokens(&body.DepositAmount.Int) {
 		return fmt.Errorf("unable to add deposit balance to account")
 	}
 	st.Update(account)

--- a/internal/chain/synthetic_token_deposit_test.go
+++ b/internal/chain/synthetic_token_deposit_test.go
@@ -28,7 +28,7 @@ func TestSynthTokenDeposit_Anon(t *testing.T) {
 	st, err := NewStateManager(db, gtx)
 	require.ErrorIs(t, err, storage.ErrNotFound)
 
-	err = SyntheticTokenDeposit{}.DeliverTx(st, gtx)
+	err = SyntheticTokenDeposit{}.Validate(st, gtx)
 	require.NoError(t, err)
 
 	//try to extract the state to see if we have a valid account

--- a/internal/chain/withdraw_tokens.go
+++ b/internal/chain/withdraw_tokens.go
@@ -18,32 +18,23 @@ type WithdrawTokens struct{}
 
 func (WithdrawTokens) Type() types.TxType { return types.TxTypeWithdrawTokens }
 
-type tokenSend struct {
-	url    *url.URL
-	amount *big.Int
-}
-
-func checkTokenTx(st *StateManager, tx *transactions.GenTransaction) ([]*tokenSend, tokenChain, *url.URL, *big.Int, error) {
+func (WithdrawTokens) Validate(st *StateManager, tx *transactions.GenTransaction) error {
 	body := new(api.TokenTx)
 	err := tx.As(body)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("invalid payload: %v", err)
+		return fmt.Errorf("invalid payload: %v", err)
 	}
 
 	if body.From.String != types.String(tx.SigInfo.URL) {
-		return nil, nil, nil, nil, fmt.Errorf("withdraw address and transaction sponsor do not match")
+		return fmt.Errorf("withdraw address and transaction sponsor do not match")
 	}
 
-	sends := make([]*tokenSend, len(body.To))
+	recipients := make([]*url.URL, len(body.To))
 	for i, to := range body.To {
-		u, err := url.Parse(*to.URL.AsString())
+		recipients[i], err = url.Parse(*to.URL.AsString())
 		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("invalid destination URL: %v", err)
+			return fmt.Errorf("invalid destination URL: %v", err)
 		}
-
-		amount := new(big.Int)
-		amount.SetUint64(to.Amount)
-		sends[i] = &tokenSend{u, amount}
 	}
 
 	var account tokenChain
@@ -53,56 +44,41 @@ func checkTokenTx(st *StateManager, tx *transactions.GenTransaction) ([]*tokenSe
 	case *protocol.AnonTokenAccount:
 		account = sponsor
 	default:
-		return nil, nil, nil, nil, fmt.Errorf("%v cannot sponsor token transactions", st.Sponsor.Header().Type)
+		return fmt.Errorf("%v cannot sponsor token transactions", st.Sponsor.Header().Type)
 	}
 
 	tokenUrl, err := account.ParseTokenUrl()
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("invalid token URL: %v", err)
+		return fmt.Errorf("invalid token URL: %v", err)
 	}
 
 	//now check to see if we can transact
 	//really only need to provide one input...
 	//now check to see if the account is good to send tokens from
-	amt := types.Amount{}
-	txAmt := big.NewInt(0)
-	for _, val := range body.To {
-		amt.Add(amt.AsBigInt(), txAmt.SetUint64(val.Amount))
+	total := types.Amount{}
+	for _, to := range body.To {
+		total.Add(total.AsBigInt(), new(big.Int).SetUint64(to.Amount))
 	}
 
-	if !account.CanDebitTokens(&amt.Int) {
-		return nil, nil, nil, nil, fmt.Errorf("insufficient balance")
-	}
-
-	return sends, account, tokenUrl, &amt.Int, nil
-}
-
-func (c WithdrawTokens) CheckTx(st *StateManager, tx *transactions.GenTransaction) error {
-	_, _, _, _, err := checkTokenTx(st, tx)
-	return err
-}
-
-func (c WithdrawTokens) DeliverTx(st *StateManager, tx *transactions.GenTransaction) error {
-	body, account, tokenUrl, debit, err := checkTokenTx(st, tx)
-	if err != nil {
-		return err
+	if !account.CanDebitTokens(&total.Int) {
+		return fmt.Errorf("insufficient balance")
 	}
 
 	token := types.String(tokenUrl.String())
 	txid := types.Bytes(tx.TransactionHash())
-	for _, send := range body {
+	for i, u := range recipients {
 		from := types.String(st.SponsorUrl.String())
-		to := types.String(send.url.String())
+		to := types.String(u.String())
 		deposit := synthetic.NewTokenTransactionDeposit(txid[:], from, to)
-		err = deposit.SetDeposit(token, send.amount)
+		err = deposit.SetDeposit(token, new(big.Int).SetUint64(body.To[i].Amount))
 		if err != nil {
 			return fmt.Errorf("invalid deposit: %v", err)
 		}
 
-		st.Submit(send.url, deposit)
+		st.Submit(u, deposit)
 	}
 
-	if !account.DebitTokens(debit) {
+	if !account.DebitTokens(&total.Int) {
 		return fmt.Errorf("%q balance is insufficient", st.SponsorUrl)
 	}
 	st.Update(account)

--- a/internal/chain/withdraw_tokens_test.go
+++ b/internal/chain/withdraw_tokens_test.go
@@ -39,7 +39,7 @@ func TestAnonTokenTransactions(t *testing.T) {
 	st, err := NewStateManager(db, gtx)
 	require.NoError(t, err)
 
-	err = WithdrawTokens{}.DeliverTx(st, gtx)
+	err = WithdrawTokens{}.Validate(st, gtx)
 	require.NoError(t, err)
 
 	//pull the chains again


### PR DESCRIPTION
Simplifies the chain validators by merging CheckTx and DeliverTx into Validate. This is feasible since pending state changes and synthetic transactions are not sent until the transaction succeeds. Thus, CheckTx can use Validate and simply discard the pending changes.

This makes no functional changes.