### PR TITLE
chore: rename chain types

### DIFF
--- a/cmd/cli/cmd/book.go
+++ b/cmd/cli/cmd/book.go
@@ -189,7 +189,7 @@ func GetKeyPageInBook(book string, keyLabel string) (*protocol.SigSpec, int, err
 		if err != nil {
 			log.Fatal(err)
 		}
-		if *s.Type.AsString() != types.ChainTypeSigSpec.Name() {
+		if *s.Type.AsString() != types.ChainTypeKeyPage.Name() {
 			log.Fatal(fmt.Errorf("expecting key page, received %s", s.Type))
 		}
 		ss := protocol.SigSpec{}

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -267,11 +267,11 @@ func (api *API) getDataByChainId(_ context.Context, params json.RawMessage) inte
 }
 
 func (api *API) getSigSpec(_ context.Context, params json.RawMessage) interface{} {
-	return api.get(params, types.ChainTypeSigSpec)
+	return api.get(params, types.ChainTypeKeyPage)
 }
 
 func (api *API) getSigSpecGroup(_ context.Context, params json.RawMessage) interface{} {
-	return api.get(params, types.ChainTypeSigSpecGroup)
+	return api.get(params, types.ChainTypeKeyBook)
 }
 
 // getADI returns ADI info

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -513,7 +513,7 @@ func TestQueryWrongType(t *testing.T) {
 	resp := japi.GetADI(context.Background(), req)
 	switch r := resp.(type) {
 	case jsonrpc2.Error:
-		require.Contains(t, r.Data, "want ChainTypeAdi, got ChainTypeAnonTokenAccount")
+		require.Contains(t, r.Data, "want identity, got liteTokenAccount")
 	default:
 		t.Fatalf("Expected error, got %T", r)
 	}

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -197,7 +197,7 @@ func (q *Query) GetAdi(adi string) (*acmeApi.APIDataResponse, error) {
 		return nil, fmt.Errorf("bvc adi query returned error, %v", err)
 	}
 
-	return unmarshalQueryResponse(r.Response, types.ChainTypeAdi)
+	return unmarshalQueryResponse(r.Response, types.ChainTypeIdentity)
 }
 
 // GetToken
@@ -208,7 +208,7 @@ func (q *Query) GetToken(tokenUrl string) (*acmeApi.APIDataResponse, error) {
 		return nil, fmt.Errorf("bvc token query returned error, %v", err)
 	}
 
-	return unmarshalQueryResponse(r.Response, types.ChainTypeToken)
+	return unmarshalQueryResponse(r.Response, types.ChainTypeTokenIssuer)
 }
 
 // GetTokenAccount get the token balance for a given url
@@ -218,7 +218,7 @@ func (q *Query) GetTokenAccount(adiChainPath string) (*acmeApi.APIDataResponse, 
 		return nil, fmt.Errorf("bvc token account query returned error, %v", err)
 	}
 
-	return unmarshalQueryResponse(r.Response, types.ChainTypeTokenAccount, types.ChainTypeAnonTokenAccount)
+	return unmarshalQueryResponse(r.Response, types.ChainTypeTokenAccount, types.ChainTypeLiteTokenAccount)
 }
 
 // GetDirectory returns directory entries for a given url

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -309,22 +309,22 @@ func unmarshalQueryResponse(rQuery tm.ResponseQuery, expect ...types.ChainType) 
 	}
 
 	switch sChain.Type {
-	case types.ChainTypeAdi:
+	case types.ChainTypeIdentity:
 		return unmarshalADI(rQuery)
 
-	case types.ChainTypeToken:
+	case types.ChainTypeTokenIssuer:
 		return unmarshalToken(rQuery)
 
 	case types.ChainTypeTokenAccount:
 		return unmarshalTokenAccount(rQuery)
 
-	case types.ChainTypeAnonTokenAccount:
+	case types.ChainTypeLiteTokenAccount:
 		return unmarshalAnonTokenAccount(rQuery)
 
-	case types.ChainTypeSigSpec:
+	case types.ChainTypeKeyPage:
 		return unmarshalSigSpec(rQuery)
 
-	case types.ChainTypeSigSpecGroup:
+	case types.ChainTypeKeyBook:
 		return unmarshalSigSpecGroup(rQuery)
 
 	case types.ChainTypeTransaction:

--- a/internal/api/v2/unmarshal.go
+++ b/internal/api/v2/unmarshal.go
@@ -27,17 +27,17 @@ func unmarshalState(b []byte) (*state.Object, state.Chain, error) {
 	}
 
 	switch header.Type {
-	case types.ChainTypeAdi:
+	case types.ChainTypeIdentity:
 		chain = new(state.AdiState)
-	case types.ChainTypeToken:
+	case types.ChainTypeTokenIssuer:
 		chain = new(state.Token)
 	case types.ChainTypeTokenAccount:
 		chain = new(state.TokenAccount)
-	case types.ChainTypeAnonTokenAccount:
+	case types.ChainTypeLiteTokenAccount:
 		chain = new(protocol.AnonTokenAccount)
-	case types.ChainTypeSigSpec:
+	case types.ChainTypeKeyPage:
 		chain = new(protocol.SigSpec)
-	case types.ChainTypeSigSpecGroup:
+	case types.ChainTypeKeyBook:
 		chain = new(protocol.SigSpecGroup)
 	case types.ChainTypeTransaction:
 		chain = new(state.Transaction)

--- a/internal/chain/add_credits.go
+++ b/internal/chain/add_credits.go
@@ -49,7 +49,7 @@ func (AddCredits) Validate(st *StateManager, tx *transactions.GenTransaction) er
 		case *protocol.AnonTokenAccount, *protocol.SigSpec:
 			// OK
 		default:
-			return fmt.Errorf("invalid recipient: wrong chain type: want %v or %v, got %v", types.ChainTypeAnonTokenAccount, types.ChainTypeSigSpec, recv.Header().Type)
+			return fmt.Errorf("invalid recipient: want chain type %v or %v, got %v", types.ChainTypeLiteTokenAccount, types.ChainTypeKeyPage, recv.Header().Type)
 		}
 	} else if errors.Is(err, storage.ErrNotFound) {
 		if recvUrl.Routing() == tx.Routing {

--- a/internal/chain/create_key_book.go
+++ b/internal/chain/create_key_book.go
@@ -16,7 +16,7 @@ func (CreateKeyBook) Type() types.TxType { return types.TxTypeCreateKeyBook }
 
 func (CreateKeyBook) Validate(st *StateManager, tx *transactions.GenTransaction) error {
 	if _, ok := st.Sponsor.(*state.AdiState); !ok {
-		return fmt.Errorf("invalid sponsor: want %v, got %v", types.ChainTypeAdi, st.Sponsor.Header().Type)
+		return fmt.Errorf("invalid sponsor: want chain type %v, got %v", types.ChainTypeIdentity, st.Sponsor.Header().Type)
 	}
 
 	body := new(protocol.CreateSigSpecGroup)

--- a/internal/chain/create_key_page.go
+++ b/internal/chain/create_key_page.go
@@ -22,7 +22,7 @@ func (CreateKeyPage) Validate(st *StateManager, tx *transactions.GenTransaction)
 	case *protocol.SigSpecGroup:
 		group = sponsor
 	default:
-		return fmt.Errorf("%v cannot sponsor a sig spec", sponsor.Header().Type)
+		return fmt.Errorf("invalid sponsor: want chain type %v or %v, got %v", types.ChainTypeIdentity, types.ChainTypeKeyBook, sponsor.Header().Type)
 	}
 
 	body := new(protocol.CreateSigSpec)

--- a/internal/chain/executor.go
+++ b/internal/chain/executor.go
@@ -319,7 +319,7 @@ func (m *Executor) check(tx *transactions.GenTransaction) (*StateManager, error)
 	default:
 		// The TX sponsor cannot be a transaction
 		// Token issue chains are not implemented
-		return nil, fmt.Errorf("%v cannot sponsor transactions", sponsor.Header().Type)
+		return nil, fmt.Errorf("invalid sponsor: chain type %v cannot sponsor transactions", sponsor.Header().Type)
 	}
 
 	if tx.SigInfo.PriorityIdx >= uint64(len(sigGroup.SigSpecs)) {

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -272,11 +272,11 @@ func unmarshalRecord(obj *state.Object) (state.Chain, error) {
 	var record state.Chain
 	switch header.Type {
 	// TODO DC, BVC, Token
-	case types.ChainTypeAdi:
+	case types.ChainTypeIdentity:
 		record = new(state.AdiState)
 	case types.ChainTypeTokenAccount:
 		record = new(state.TokenAccount)
-	case types.ChainTypeAnonTokenAccount:
+	case types.ChainTypeLiteTokenAccount:
 		record = new(protocol.AnonTokenAccount)
 	case types.ChainTypeTransactionReference:
 		record = new(state.TxReference)
@@ -284,9 +284,9 @@ func unmarshalRecord(obj *state.Object) (state.Chain, error) {
 		record = new(state.Transaction)
 	case types.ChainTypePendingTransaction:
 		record = new(state.PendingTransaction)
-	case types.ChainTypeSigSpec:
+	case types.ChainTypeKeyPage:
 		record = new(protocol.SigSpec)
-	case types.ChainTypeSigSpecGroup:
+	case types.ChainTypeKeyBook:
 		record = new(protocol.SigSpecGroup)
 	default:
 		return nil, fmt.Errorf("unrecognized chain type %v", header.Type)

--- a/internal/chain/synthetic_chain_create_test.go
+++ b/internal/chain/synthetic_chain_create_test.go
@@ -38,5 +38,5 @@ func TestSyntheticChainCreate_MultiSlash(t *testing.T) {
 	require.NoError(t, err)
 
 	err = SyntheticCreateChain{}.Validate(st, tx)
-	require.EqualError(t, err, `ChainTypeTokenAccount cannot contain more than one slash in its URL`)
+	require.EqualError(t, err, `chain type tokenAccount cannot contain more than one slash in its URL`)
 }

--- a/internal/chain/synthetic_create_chain.go
+++ b/internal/chain/synthetic_create_chain.go
@@ -67,7 +67,7 @@ func (SyntheticCreateChain) Validate(st *StateManager, tx *transactions.GenTrans
 
 		// Check the identity
 		switch record.Header().Type {
-		case types.ChainTypeAdi:
+		case types.ChainTypeIdentity:
 			// An ADI must be its own identity
 			if !u.Identity().Equal(u) {
 				return fmt.Errorf("ADI is not its own identity")
@@ -75,11 +75,11 @@ func (SyntheticCreateChain) Validate(st *StateManager, tx *transactions.GenTrans
 		default:
 			// Anything else must be a sub-path
 			if u.Identity().Equal(u) {
-				return fmt.Errorf("%v cannot be its own identity", record.Header().Type)
+				return fmt.Errorf("chain type %v cannot be its own identity", record.Header().Type)
 			}
 
 			if u.Path != "" && strings.Contains(u.Path[1:], "/") {
-				return fmt.Errorf("%v cannot contain more than one slash in its URL", record.Header().Type)
+				return fmt.Errorf("chain type %v cannot contain more than one slash in its URL", record.Header().Type)
 			}
 
 			// Make sure the ADI actually exists
@@ -99,13 +99,13 @@ func (SyntheticCreateChain) Validate(st *StateManager, tx *transactions.GenTrans
 
 		// Check the key book
 		switch record.Header().Type {
-		case types.ChainTypeSigSpecGroup:
+		case types.ChainTypeKeyBook:
 			// A key book does not itself have a key book
 			if record.Header().SigSpecId != (types.Bytes32{}) {
 				return errors.New("invalid key book: SigSpecId is not empty")
 			}
 
-		case types.ChainTypeSigSpec:
+		case types.ChainTypeKeyPage:
 			// A key page can be unbound
 
 		default:

--- a/internal/chain/synthetic_deposit_credits.go
+++ b/internal/chain/synthetic_deposit_credits.go
@@ -28,7 +28,7 @@ func (SyntheticDepositCredits) Validate(st *StateManager, tx *transactions.GenTr
 		account = sponsor
 
 	default:
-		return fmt.Errorf("cannot deposit tokens into a %v", st.Sponsor.Header().Type)
+		return fmt.Errorf("invalid sponsor: want chain type %v or %v, got %v", types.ChainTypeLiteTokenAccount, types.ChainTypeKeyPage, st.Sponsor.Header().Type)
 	}
 
 	account.CreditCredits(body.Amount)

--- a/internal/chain/synthetic_token_deposit.go
+++ b/internal/chain/synthetic_token_deposit.go
@@ -47,7 +47,7 @@ func (SyntheticTokenDeposit) Validate(st *StateManager, tx *transactions.GenTran
 		case *state.TokenAccount:
 			account = sponsor
 		default:
-			return fmt.Errorf("cannot deposit tokens to %v", sponsor.Header().Type)
+			return fmt.Errorf("invalid sponsor: want chain type %v or %v, got %v", types.ChainTypeLiteTokenAccount, types.ChainTypeTokenAccount, sponsor.Header().Type)
 		}
 	} else if keyHash, tok, err := protocol.ParseAnonymousAddress(accountUrl); err != nil {
 		return fmt.Errorf("invalid anonymous token account URL: %v", err)

--- a/internal/chain/synthetic_token_deposit_test.go
+++ b/internal/chain/synthetic_token_deposit_test.go
@@ -35,7 +35,7 @@ func TestSynthTokenDeposit_Anon(t *testing.T) {
 	tas := new(protocol.AnonTokenAccount)
 	require.NoError(t, st.LoadAs(st.SponsorChainId, tas))
 	require.Equal(t, types.String(gtx.SigInfo.URL), tas.ChainUrl, "invalid chain header")
-	require.Equalf(t, types.ChainTypeAnonTokenAccount, tas.Type, "chain state is not an anon account, it is %s", tas.ChainHeader.Type.Name())
+	require.Equalf(t, types.ChainTypeLiteTokenAccount, tas.Type, "chain state is not an anon account, it is %s", tas.ChainHeader.Type.Name())
 	require.Equal(t, tokenUrl, tas.TokenUrl, "token url of state doesn't match expected")
 	require.Equal(t, uint64(1), tas.TxCount)
 

--- a/internal/chain/update_key_page.go
+++ b/internal/chain/update_key_page.go
@@ -24,7 +24,7 @@ func (UpdateKeyPage) Validate(st *StateManager, tx *transactions.GenTransaction)
 
 	page, ok := st.Sponsor.(*protocol.SigSpec)
 	if !ok {
-		return fmt.Errorf("invalid sponsor: want %v, got %v", types.ChainTypeSigSpec, st.Sponsor.Header().Type)
+		return fmt.Errorf("invalid sponsor: want chain type %v, got %v", types.ChainTypeKeyPage, st.Sponsor.Header().Type)
 	}
 
 	// We're changing the height of the key page, so reset all the nonces

--- a/internal/chain/withdraw_tokens.go
+++ b/internal/chain/withdraw_tokens.go
@@ -44,7 +44,7 @@ func (WithdrawTokens) Validate(st *StateManager, tx *transactions.GenTransaction
 	case *protocol.AnonTokenAccount:
 		account = sponsor
 	default:
-		return fmt.Errorf("%v cannot sponsor token transactions", st.Sponsor.Header().Type)
+		return fmt.Errorf("invalid sponsor: want %v or %v, got %v", types.ChainTypeTokenAccount, types.ChainTypeLiteTokenAccount, st.Sponsor.Header().Type)
 	}
 
 	tokenUrl, err := account.ParseTokenUrl()

--- a/internal/genesis/acme.go
+++ b/internal/genesis/acme.go
@@ -9,7 +9,7 @@ import (
 var ACME = new(state.Token)
 
 func createAcmeToken() state.Chain {
-	ACME.Type = types.ChainTypeToken
+	ACME.Type = types.ChainTypeTokenIssuer
 
 	ACME.ChainUrl = types.String(protocol.AcmeUrl().String())
 	ACME.Precision = 8

--- a/internal/node/e2e_test.go
+++ b/internal/node/e2e_test.go
@@ -148,6 +148,6 @@ func TestFaucetMultiNetwork(t *testing.T) {
 	require.Zero(t, qres.Response.Code, "Failed, log=%q, info=%q", qres.Response.Log, qres.Response.Info)
 	require.NoError(t, obj.UnmarshalBinary(qres.Response.Value))
 	require.NoError(t, obj.As(chain))
-	require.Equal(t, types.ChainTypeAnonTokenAccount, chain.Type)
+	require.Equal(t, types.ChainTypeLiteTokenAccount, chain.Type)
 	require.NoError(t, obj.As(account))
 }

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -35,6 +35,7 @@ TxSynthRef:
 
 AnonTokenAccount:
   kind: chain
+  chain-type: LiteTokenAccount
   fields:
     - name: TokenUrl
       type: string
@@ -96,6 +97,7 @@ KeySpecParams:
 
 SigSpec:
   kind: chain
+  chain-type: KeyPage
   fields:
     - name: CreditBalance
       type: bigint
@@ -122,6 +124,7 @@ CreateSigSpec:
 
 SigSpecGroup:
   kind: chain
+  chain-type: KeyBook
   fields:
     - name: SigSpecs
       type: chainSet

--- a/protocol/types_gen.go
+++ b/protocol/types_gen.go
@@ -125,19 +125,19 @@ type UpdateKeyPage struct {
 
 func NewAnonTokenAccount() *AnonTokenAccount {
 	v := new(AnonTokenAccount)
-	v.Type = types.ChainTypeAnonTokenAccount
+	v.Type = types.ChainTypeLiteTokenAccount
 	return v
 }
 
 func NewSigSpec() *SigSpec {
 	v := new(SigSpec)
-	v.Type = types.ChainTypeSigSpec
+	v.Type = types.ChainTypeKeyPage
 	return v
 }
 
 func NewSigSpecGroup() *SigSpecGroup {
 	v := new(SigSpecGroup)
-	v.Type = types.ChainTypeSigSpecGroup
+	v.Type = types.ChainTypeKeyBook
 	return v
 }
 
@@ -177,7 +177,7 @@ func (v *AnonTokenAccount) BinarySize() int {
 	var n int
 
 	// Enforce sanity
-	v.Type = types.ChainTypeAnonTokenAccount
+	v.Type = types.ChainTypeLiteTokenAccount
 
 	n += v.ChainHeader.GetHeaderSize()
 
@@ -302,7 +302,7 @@ func (v *SigSpec) BinarySize() int {
 	var n int
 
 	// Enforce sanity
-	v.Type = types.ChainTypeSigSpec
+	v.Type = types.ChainTypeKeyPage
 
 	n += v.ChainHeader.GetHeaderSize()
 
@@ -322,7 +322,7 @@ func (v *SigSpecGroup) BinarySize() int {
 	var n int
 
 	// Enforce sanity
-	v.Type = types.ChainTypeSigSpecGroup
+	v.Type = types.ChainTypeKeyBook
 
 	n += v.ChainHeader.GetHeaderSize()
 
@@ -439,7 +439,7 @@ func (v *AnonTokenAccount) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
 
 	// Enforce sanity
-	v.Type = types.ChainTypeAnonTokenAccount
+	v.Type = types.ChainTypeLiteTokenAccount
 
 	if b, err := v.ChainHeader.MarshalBinary(); err != nil {
 		return nil, fmt.Errorf("error encoding header: %w", err)
@@ -571,7 +571,7 @@ func (v *SigSpec) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
 
 	// Enforce sanity
-	v.Type = types.ChainTypeSigSpec
+	v.Type = types.ChainTypeKeyPage
 
 	if b, err := v.ChainHeader.MarshalBinary(); err != nil {
 		return nil, fmt.Errorf("error encoding header: %w", err)
@@ -598,7 +598,7 @@ func (v *SigSpecGroup) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
 
 	// Enforce sanity
-	v.Type = types.ChainTypeSigSpecGroup
+	v.Type = types.ChainTypeKeyBook
 
 	if b, err := v.ChainHeader.MarshalBinary(); err != nil {
 		return nil, fmt.Errorf("error encoding header: %w", err)
@@ -741,7 +741,7 @@ func (v *AddCredits) UnmarshalBinary(data []byte) error {
 }
 
 func (v *AnonTokenAccount) UnmarshalBinary(data []byte) error {
-	typ := types.ChainTypeAnonTokenAccount
+	typ := types.ChainTypeLiteTokenAccount
 	if err := v.ChainHeader.UnmarshalBinary(data); err != nil {
 		return fmt.Errorf("error decoding header: %w", err)
 	} else if v.Type != typ {
@@ -991,7 +991,7 @@ func (v *MetricsRequest) UnmarshalBinary(data []byte) error {
 }
 
 func (v *SigSpec) UnmarshalBinary(data []byte) error {
-	typ := types.ChainTypeSigSpec
+	typ := types.ChainTypeKeyPage
 	if err := v.ChainHeader.UnmarshalBinary(data); err != nil {
 		return fmt.Errorf("error decoding header: %w", err)
 	} else if v.Type != typ {
@@ -1029,7 +1029,7 @@ func (v *SigSpec) UnmarshalBinary(data []byte) error {
 }
 
 func (v *SigSpecGroup) UnmarshalBinary(data []byte) error {
-	typ := types.ChainTypeSigSpecGroup
+	typ := types.ChainTypeKeyBook
 	if err := v.ChainHeader.UnmarshalBinary(data); err != nil {
 		return fmt.Errorf("error decoding header: %w", err)
 	} else if v.Type != typ {

--- a/types/chain_types.go
+++ b/types/chain_types.go
@@ -1,79 +1,58 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 )
 
+// ChainType is the type of a chain.
 type ChainType uint64
 
-//ChainType enumeration order matters, do not change order or insert new enums.
 const (
-	ChainTypeUnknown              = ChainType(iota)
-	ChainTypeDC                   // Directory Chain
-	ChainTypeBVC                  // Block Validator Chain
-	ChainTypeAdi                  // Accumulate Digital/Distributed Identity/Identifier/Domain
-	ChainTypeToken                // Token Issue
-	ChainTypeTokenAccount         // Token Account
-	ChainTypeAnonTokenAccount     // Anonymous Token Account
-	ChainTypeTransactionReference // Transaction Reference Chain
-	ChainTypeTransaction          // Transaction Chain
-	ChainTypePendingTransaction   // Pending Chain
-	ChainTypeSigSpec              // Signature Specification chain
-	ChainTypeSigSpecGroup         // Signature Specification Group chain
+	// ChainTypeUnknown represents an unknown chain type.
+	ChainTypeUnknown = ChainType(iota)
+
+	chainMax = ChainTypeKeyBook
 )
 
-// Enum value maps for ChainType.
-var (
-	ChainTypeName = map[ChainType]string{
-		ChainTypeUnknown:              "ChainTypeUnknown",
-		ChainTypeDC:                   "ChainTypeDC",
-		ChainTypeBVC:                  "ChainTypeBVC",
-		ChainTypeAdi:                  "ChainTypeAdi",
-		ChainTypeToken:                "ChainTypeToken",
-		ChainTypeTokenAccount:         "ChainTypeTokenAccount",
-		ChainTypeAnonTokenAccount:     "ChainTypeAnonTokenAccount",
-		ChainTypeTransactionReference: "ChainTypeTransactionReference",
-		ChainTypeTransaction:          "ChainTypeTransaction",
-		ChainTypePendingTransaction:   "ChainTypePendingTransaction",
-		ChainTypeSigSpec:              "ChainTypeSigSpec",
-		ChainTypeSigSpecGroup:         "ChainTypeSigSpecGroup",
-	}
-	ChainTypeValue = map[string]ChainType{
-		"ChainTypeUnknown":              ChainTypeUnknown,
-		"ChainTypeDC":                   ChainTypeDC,
-		"ChainTypeBVC":                  ChainTypeBVC,
-		"ChainTypeAdi":                  ChainTypeAdi,
-		"ChainTypeToken":                ChainTypeToken,
-		"ChainTypeTokenAccount":         ChainTypeTokenAccount,
-		"ChainTypeAnonTokenAccount":     ChainTypeAnonTokenAccount,
-		"ChainTypeTransactionReference": ChainTypeTransactionReference,
-		"ChainTypeTransaction":          ChainTypeTransaction,
-		"ChainTypePendingTransaction":   ChainTypePendingTransaction,
-		"ChainTypeSigSpec":              ChainTypeSigSpec,
-		"ChainTypeSigSpecGroup":         ChainTypeSigSpecGroup,
-	}
+const (
+	// ChainTypeIdentity is an Identity chain, aka an ADI.
+	ChainTypeIdentity ChainType = 2
+
+	// ChainTypeTokenIssuer is a Token Issuer chain.
+	ChainTypeTokenIssuer ChainType = 3
+
+	// ChainTypeTokenAccount is an ADI Token Account chain.
+	ChainTypeTokenAccount ChainType = 4
+
+	// ChainTypeLiteTokenAccount is a Lite Token Account chain.
+	ChainTypeLiteTokenAccount ChainType = 5
+
+	// ChainTypeTransactionReference is a reference to a transaction.
+	ChainTypeTransactionReference ChainType = 6
+
+	// ChainTypeTransaction is a completed transaction.
+	ChainTypeTransaction ChainType = 7
+
+	// ChainTypeTransaction is a pending transaction.
+	ChainTypePendingTransaction ChainType = 8
+
+	// ChainTypeKeyPage is a key page chain.
+	ChainTypeKeyPage ChainType = 9
+
+	// ChainTypeKeyBook is a key book chain.
+	ChainTypeKeyBook ChainType = 10
+
+	// TODO Directory node anchor chain?
+
+	// TODO Block validator node anchor chain?
 )
 
-//Name will return the name of the type
-func (t ChainType) Name() string {
-	if name := ChainTypeName[t]; name != "" {
-		return name
-	}
-	return ChainTypeUnknown.Name()
-}
+// ID returns the chain type ID
+func (t ChainType) ID() uint64 { return uint64(t) }
 
-//SetType will set the type based on the string name submitted
-func (t *ChainType) SetType(s string) {
-	*t = ChainTypeValue[s]
-}
-
-//AsUint64 casts as a uint64
-func (t ChainType) AsUint64() uint64 {
-	return uint64(t)
-}
-
-func (t ChainType) String() string { return t.Name() }
-
+// IsTransaction returns true if the chain type is a transaction.
 func (t ChainType) IsTransaction() bool {
 	switch t {
 	case ChainTypeTransaction, ChainTypeTransactionReference, ChainTypePendingTransaction:
@@ -83,18 +62,61 @@ func (t ChainType) IsTransaction() bool {
 	}
 }
 
-func (t *ChainType) UnmarshalJSON(data []byte) error {
-	var s String
-	err := s.UnmarshalJSON(data)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling chain type")
+// String returns the name of the chain type
+func (t ChainType) String() string {
+	switch t {
+	case ChainTypeUnknown:
+		return "unknown"
+	case ChainTypeIdentity:
+		return "identity"
+	case ChainTypeTokenIssuer:
+		return "token"
+	case ChainTypeTokenAccount:
+		return "tokenAccount"
+	case ChainTypeLiteTokenAccount:
+		return "liteTokenAccount"
+	case ChainTypeTransactionReference:
+		return "transactionReference"
+	case ChainTypeTransaction:
+		return "transaction"
+	case ChainTypePendingTransaction:
+		return "pendingTransaction"
+	case ChainTypeKeyPage:
+		return "keyPage"
+	case ChainTypeKeyBook:
+		return "keyBook"
+	default:
+		return fmt.Sprintf("ChainType:%d", t)
 	}
-	t.SetType(*s.AsString())
+}
 
+// Name is an alias for String
+// Deprecated: use String
+func (t ChainType) Name() string { return t.String() }
+
+var chainByName = map[string]ChainType{}
+
+func init() {
+	for t := ChainTypeUnknown; t < chainMax; t++ {
+		chainByName[t.String()] = t
+	}
+}
+
+func (t *ChainType) UnmarshalJSON(data []byte) error {
+	var s string
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+
+	var ok bool
+	*t, ok = chainByName[s]
+	if !ok || strings.ContainsRune(t.String(), ':') {
+		return fmt.Errorf("invalid transaction type %q", s)
+	}
 	return nil
 }
 
-func (t *ChainType) MarshalJSON() ([]byte, error) {
-	s := String(t.String())
-	return s.MarshalJSON()
+func (t ChainType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }

--- a/types/state/ADI.go
+++ b/types/state/ADI.go
@@ -48,13 +48,13 @@ type AdiState struct {
 // NewIdentityState this will eventually be the key groups and potentially just a multi-map of types to chain paths controlled by the identity
 func NewIdentityState(adi types.String) *AdiState {
 	r := &AdiState{}
-	r.SetHeader(adi, types.ChainTypeAdi)
+	r.SetHeader(adi, types.ChainTypeIdentity)
 	return r
 }
 
 func NewADI(url types.String, keyType KeyType, keyData []byte) *AdiState {
 	r := new(AdiState)
-	r.SetHeader(url, types.ChainTypeAdi)
+	r.SetHeader(url, types.ChainTypeIdentity)
 	r.KeyType = keyType
 	r.KeyData = keyData
 	return r

--- a/types/state/Chain.go
+++ b/types/state/Chain.go
@@ -39,7 +39,7 @@ func (h *ChainHeader) SetHeader(chainUrl types.String, chainType types.ChainType
 //GetHeaderSize will return the marshalled binary size of the header.
 func (h *ChainHeader) GetHeaderSize() int {
 	var buf [8]byte
-	i := binary.PutUvarint(buf[:], h.Type.AsUint64())
+	i := binary.PutUvarint(buf[:], h.Type.ID())
 	i += binary.PutUvarint(buf[:], uint64(len(h.ChainUrl)))
 	i += binary.PutUvarint(buf[:], uint64(len(h.SigSpecId)))
 	return i + len(h.ChainUrl) + len(h.SigSpecId)
@@ -74,7 +74,7 @@ func (h *ChainHeader) ParseUrl() (*url.URL, error) {
 func (h *ChainHeader) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
 
-	buffer.Write(common.Uint64Bytes(h.Type.AsUint64()))
+	buffer.Write(common.Uint64Bytes(h.Type.ID()))
 	buffer.Write(common.SliceBytes([]byte(h.ChainUrl)))
 	buffer.Write(common.SliceBytes(h.SigSpecId[:]))
 

--- a/types/state/Chain_test.go
+++ b/types/state/Chain_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestStateHeader(t *testing.T) {
 
-	header := ChainHeader{ChainUrl: "acme/chain/path", Type: types.ChainTypeAnonTokenAccount}
+	header := ChainHeader{ChainUrl: "acme/chain/path", Type: types.ChainTypeLiteTokenAccount}
 
 	data, err := header.MarshalBinary()
 	if err != nil {

--- a/types/state/Object_test.go
+++ b/types/state/Object_test.go
@@ -13,7 +13,7 @@ func TestStateObject(t *testing.T) {
 
 	adi := types.String("myadi")
 	chain := new(ChainHeader)
-	chain.SetHeader(adi, types.ChainTypeAnonTokenAccount)
+	chain.SetHeader(adi, types.ChainTypeLiteTokenAccount)
 	so.Entry, err = chain.MarshalBinary()
 	if err != nil {
 		t.Fatal(err)

--- a/types/state/Token.go
+++ b/types/state/Token.go
@@ -17,7 +17,7 @@ type Token struct {
 
 func NewToken(tokenUrl string) *Token {
 	token := &Token{}
-	token.SetHeader(types.String(tokenUrl), types.ChainTypeToken)
+	token.SetHeader(types.String(tokenUrl), types.ChainTypeTokenIssuer)
 	return token
 }
 


### PR DESCRIPTION
- Updates out-of-date chain types.
  - Anon token account => lite token account
  - Sig spec group => key book
  - Sig spec => key page
- Renames `ChainTypeAdi` to `ChainTypeIdentity` so that it matches `TxTypeCreateIdentity`
- Updates chain type JSON marshalling
  - `ChainTypeTokenAccount` now marshals to `"tokenAccount"` instead of `"ChainTypeTokenAccount"`

The only functional change is to the JSON marshalling of chain types.