### PR TITLE
fix: return an error if count is zero

### DIFF
--- a/internal/api/v2/jrpc_query.go
+++ b/internal/api/v2/jrpc_query.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 )
 
 func (m *JrpcMethods) Query(_ context.Context, params json.RawMessage) interface{} {
@@ -54,7 +55,7 @@ func (m *JrpcMethods) QueryTxHistory(_ context.Context, params json.RawMessage) 
 
 	// If the user wants nothing, give them nothing
 	if req.Count == 0 {
-		return new(QueryMultiResponse)
+		return validatorError(errors.New("count must be greater than 0"))
 	}
 
 	res, err := m.opts.Query.QueryTxHistory(req.Url, int64(req.Start), int64(req.Count))


### PR DESCRIPTION
Returns an error if count is zero.

To validate, run a local node and execute:

```shell
curl -X POST --data '{ "jsonrpc": "2.0", "id": 0, "method": "query-tx-history", "params": { "url": "e7ebdb79f46fd8f902f38b9bc8bc0d14906139a024cb1836/ACME" } }' -H 'content-type:application/json;' http://127.0.1.1:26660/v2
```

This should result in:

```json
{"jsonrpc":"2.0","error":{"code":-32802,"message":"Validation Error","data":"count must be greater than 0"},"id":0}
```
