### PR TITLE
feat: faucet TX and api v2

### DIFF
--- a/internal/abci/e2e_proofs_test.go
+++ b/internal/abci/e2e_proofs_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestProofADI(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error")
+	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
 
 	// Setup keys and the lite account
 	liteKey, adiKey := generateKey(), generateKey()

--- a/internal/abci/e2e_statedb_test.go
+++ b/internal/abci/e2e_statedb_test.go
@@ -21,7 +21,7 @@ func TestStateDBConsistency(t *testing.T) {
 	sdb := new(state.StateDB)
 	require.NoError(t, sdb.Load(db, true))
 
-	n := createApp(t, sdb, crypto.Address{}, "error")
+	n := createApp(t, sdb, crypto.Address{}, "error", false)
 	n.testAnonTx(10)
 
 	height := sdb.BlockIndex()
@@ -36,6 +36,6 @@ func TestStateDBConsistency(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%X", rootHash), fmt.Sprintf("%X", sdb.RootHash()), "Hash does not match after load from disk")
 
 	// Recreate the app and try to do more transactions
-	n = createApp(t, sdb, crypto.Address{}, "error")
+	n = createApp(t, sdb, crypto.Address{}, "error", false)
 	n.testAnonTx(10)
 }

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AccumulateNetwork/accumulate/internal/abci"
 	accapi "github.com/AccumulateNetwork/accumulate/internal/api"
 	"github.com/AccumulateNetwork/accumulate/internal/chain"
+	"github.com/AccumulateNetwork/accumulate/internal/genesis"
 	"github.com/AccumulateNetwork/accumulate/internal/logging"
 	"github.com/AccumulateNetwork/accumulate/internal/relay"
 	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
@@ -33,15 +34,15 @@ import (
 	tmed25519 "github.com/tendermint/tendermint/crypto/ed25519"
 )
 
-func createAppWithMemDB(t testing.TB, addr crypto.Address, logLevel string) *fakeNode {
+func createAppWithMemDB(t testing.TB, addr crypto.Address, logLevel string, doGenesis bool) *fakeNode {
 	db := new(state.StateDB)
 	err := db.Open("memory", true, true)
 	require.NoError(t, err)
 
-	return createApp(t, db, addr, logLevel)
+	return createApp(t, db, addr, logLevel, doGenesis)
 }
 
-func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel string) *fakeNode {
+func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel string, doGenesis bool) *fakeNode {
 	_, bvcKey, _ := ed25519.GenerateKey(rand)
 
 	n := new(fakeNode)
@@ -91,6 +92,16 @@ func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel st
 	n.app, err = abci.NewAccumulator(db, addr, mgr, logger)
 	require.NoError(t, err)
 	appChan <- n.app
+
+	if doGenesis {
+		n.Batch(func(send func(*transactions.GenTransaction)) {
+			tx, err := transactions.New(protocol.ACME, func(hash []byte) (*transactions.ED25519Sig, error) {
+				return genesis.FaucetWallet.Sign(hash), nil
+			}, new(protocol.SyntheticGenesis))
+			require.NoError(t, err)
+			send(tx)
+		})
+	}
 
 	return n
 }

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -257,6 +257,8 @@ func unmarshalTransaction(sigInfo *transactions.SignatureInfo, txPayload []byte,
 		resp, err = unmarshalTxAs(txPayload, new(protocol.SyntheticDepositCredits))
 	case types.TxTypeSyntheticGenesis:
 		resp, err = unmarshalTxAs(txPayload, new(protocol.SyntheticGenesis))
+	case types.TxTypeAcmeFaucet:
+		resp, err = unmarshalTxAs(txPayload, new(protocol.AcmeFaucet))
 	default:
 		err = fmt.Errorf("unable to extract transaction info for type %s : %x", types.TxType(txType).Name(), txPayload)
 	}

--- a/internal/api/v2/jrpc.go
+++ b/internal/api/v2/jrpc.go
@@ -85,6 +85,7 @@ func NewJrpc(opts JrpcOptions) (*JrpcMethods, error) {
 		// General
 		"version": m.Version,
 		"metrics": m.Metrics,
+		"faucet":  m.Faucet,
 
 		// Query
 		"query":            m.Query,
@@ -103,7 +104,6 @@ func NewJrpc(opts JrpcOptions) (*JrpcMethods, error) {
 		"send-tokens":          m.ExecuteWith(func() PL { return new(api.TokenTx) }),
 		"add-credits":          m.ExecuteWith(func() PL { return new(protocol.AddCredits) }),
 		"update-key-page":      m.ExecuteWith(func() PL { return new(protocol.UpdateKeyPage) }),
-		// TODO faucet
 	}
 
 	return m, nil

--- a/internal/chain/acme_faucet.go
+++ b/internal/chain/acme_faucet.go
@@ -1,0 +1,87 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/AccumulateNetwork/accumulate/internal/genesis"
+	"github.com/AccumulateNetwork/accumulate/internal/url"
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
+
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulate/types/synthetic"
+)
+
+type AcmeFaucet struct{}
+
+func (AcmeFaucet) Type() types.TxType { return types.TxTypeAcmeFaucet }
+
+func (AcmeFaucet) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	// Unmarshal the TX payload
+	body := new(protocol.AcmeFaucet)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	u, err := url.Parse(body.Url)
+	if err != nil {
+		return fmt.Errorf("invalid recipient URL: %v", err)
+	}
+
+	// Check the recipient
+	account := new(protocol.AnonTokenAccount)
+	err = st.LoadUrlAs(u, account)
+	switch {
+	case err == nil:
+		// If the recipient exists, it must be an ACME lite account
+		u, err := account.ParseTokenUrl()
+		if err != nil {
+			return fmt.Errorf("invalid record: bad token URL: %v", err)
+		}
+
+		if !protocol.AcmeUrl().Equal(u) {
+			return fmt.Errorf("invalid recipient: %q is not an ACME account", u)
+		}
+
+	case errors.Is(err, storage.ErrNotFound):
+		// If the recipient doesn't exist, ensure it is an ACME lite address
+		addr, tok, err := protocol.ParseAnonymousAddress(u)
+		switch {
+		case err != nil:
+			return fmt.Errorf("error parsing lite address %q: %v", u, err)
+		case addr == nil:
+			return fmt.Errorf("invalid recipient: %q is not a lite address", u)
+		case !protocol.AcmeUrl().Equal(tok):
+			return fmt.Errorf("invalid recipient: %q is not an ACME account", u)
+		}
+
+	default:
+		return fmt.Errorf("invalid recipient: %v", err)
+	}
+
+	// Load the faucet state
+	faucet := new(protocol.AnonTokenAccount)
+	err = st.LoadUrlAs(genesis.FaucetUrl, faucet)
+	if err != nil {
+		return fmt.Errorf("failed to load faucet: %v", err)
+	}
+
+	// Attach this TX to the faucet (don't bother debiting)
+	st.Update(faucet)
+
+	// Submit a synthetic deposit token TX
+	txid := types.Bytes(tx.TransactionHash())
+	amount := new(big.Int).SetUint64(10 * protocol.AcmePrecision)
+	deposit := synthetic.NewTokenTransactionDeposit(txid[:], types.String(genesis.FaucetUrl.String()), types.String(u.String()))
+	err = deposit.SetDeposit(protocol.ACME, amount)
+	if err != nil {
+		return fmt.Errorf("invalid deposit: %v", err)
+	}
+	st.Submit(u, deposit)
+
+	return nil
+}

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -24,6 +24,9 @@ func NewBlockValidator(query *accapi.Query, db *state.StateDB, key ed25519.Priva
 		SyntheticCreateChain{},
 		SyntheticTokenDeposit{},
 		SyntheticDepositCredits{},
+
+		// TODO Only for TestNet
+		AcmeFaucet{},
 	)
 }
 

--- a/internal/genesis/faucet.go
+++ b/internal/genesis/faucet.go
@@ -14,6 +14,10 @@ import (
 var FaucetWallet transactions.WalletEntry
 var FaucetUrl *url.URL
 
+// TODO Set the balance to 0 and/or use a bogus URL for the faucet. Otherwise, a
+// bad actor could generate the faucet private key using the same method we do,
+// then sign arbitrary transactions using the faucet.
+
 func init() {
 	FaucetWallet.Nonce = 1
 
@@ -31,6 +35,7 @@ func createFaucet() state.Chain {
 
 	anon.ChainUrl = types.String(FaucetWallet.Addr)
 	anon.TokenUrl = protocol.AcmeUrl().String()
+
 	anon.Balance.SetString("314159265358979323846264338327950288419716939937510582097494459", 10)
 	return anon
 }

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -268,3 +268,10 @@ SyntheticBurnTokens:
   fields:
   - name: Amount
     type: bigint
+
+AcmeFaucet:
+  kind: tx
+  fields:
+  - name: Url
+    type: string
+    is-url: true

--- a/types/transaction_types.go
+++ b/types/transaction_types.go
@@ -50,6 +50,10 @@ const (
 	// synthetic write data transaction.
 	TxTypeWriteDataTo TransactionType = 0x06
 
+	// TxTypeAcmeFaucet produces a synthetic deposit tokens transaction that
+	// deposits ACME tokens into a lite account.
+	TxTypeAcmeFaucet TransactionType = 0x07
+
 	// TxTypeCreateToken creates a token issuer, which produces a synthetic
 	// chain create transaction.
 	TxTypeCreateToken TransactionType = 0x08
@@ -118,6 +122,8 @@ func (t TransactionType) String() string {
 		return "createTokenAccount"
 	case TxTypeWithdrawTokens:
 		return "withdrawTokens"
+	case TxTypeAcmeFaucet:
+		return "acmeFaucet"
 	case TxTypeCreateKeyPage:
 		return "createKeyPage"
 	case TxTypeCreateKeyBook:


### PR DESCRIPTION
Adds an ACME faucet TX and adds a faucet method to API v2.

Test with `curl -X POST --data '{ "jsonrpc": "2.0", "id": 0, "method": "faucet", "params": { "url": "..." } }' -H 'content-type:application/json;' http://127.0.1.1:26660/v2`. Fill in the URL with your lite account address. Verify with `cli account get ...` and `cli tx history 7117c50f04f1254d56b704dc05298912deeb25dbc1d26ef6/ACME 0 10` (faucet history).