### PR TITLE
feat: stub out remaining TXs and chains

### DIFF
--- a/docs/Records.md
+++ b/docs/Records.md
@@ -1,6 +1,6 @@
 # Accumulate Data Records
 
-- **Lite Account**
+- **Lite Token Account**
   - A token account, independent of any other record
   - Identified solely by a public key (hash) and token issuer URL
   - A lite account may only hold one type of token, which must match the account
@@ -22,3 +22,8 @@
 - **Key page**, previously (Multi) Signature Specification
   - A set of key specifications
   - Belongs to an ADI
+- **Lite Data Account**
+  - A data account, independent of any other record
+  - Identified solely by a hash
+- **ADI Data Account**
+  - A data account associated with an ADI

--- a/docs/Transactions.md
+++ b/docs/Transactions.md
@@ -1,9 +1,9 @@
 # Accumulate Transactions
 
-- **Identity Create**
+- **Create Identity**
   - Create an ADI
-  - Sponsored by an ADI or Lite Account
-- **Token Account Create**
+  - Sponsored by an ADI or Lite Token Account
+- **Create Token Account**
   - Create an ADI Token Account
   - Sponsored by an ADI
 - **Token Exchange**
@@ -22,20 +22,42 @@
 - **Add Credits**
   - Spend ACME tokens to add credits to a signator
   - Sponsored by a token account (ADI or Lite) holding ACME tokens
-  - Recipient must be a signator (Lite Account or Signature Specification)
+  - Recipient must be a signator (Lite Token Account or Signature Specification)
 - **Update Key Page**
   - Add, remove, or update a key in a key page
   - Sponsored by a key page
+- **Create Data Account**
+  - Create an ADI Data Account
+  - Sponsored by an ADI
+- **Write Data**
+  - Write data to an ADI Data Account
+  - Sponsored by an ADI Data Account
+- **Write Data To**
+  - Write data to an Lite Data Account
+  - Sponsored by an ADI or Lite Token Account
+- **Issue Tokens**
+  - Issue tokens to a token account (ADI or Lite)
+  - Sponsored by a Token Issuer
+- **Burn Tokens**
+  - Burn tokens from a token account (ADI or Lite)
+  - Sponsored by a token account (ADI or Lite)
 
 ## Synthetic
 
 - **Synthetic Create Chain**
   - Creates chains
   - Sponsor is ignored
-- **Synthetic Token Deposit**
+- **Synthetic Write Data**
+  - Writes data to a Lite Data Account
+  - Sponsored by the Lite Data Account
+  - Creates a Lite Data Account if the sponsor is a Lite Data Address with no corresponding account
+- **Synthetic Deposit Tokens**
   - Deposits tokens into an account
   - Sponsored by a token account (ADI or Lite)
-  - Creates a Lite Account if the sponsor is a Lite Address with no corresponding account
+  - Creates a Lite Token Account if the sponsor is a Lite Token Address with no corresponding account
 - **Synthetic Deposit Credits**
   - Deposits credits into a signator
-  - Sponsored by a signator (Lite Account or Signature Specification)
+  - Sponsored by a signator (Lite Token Account or Signature Specification)
+- **Synthetic Burn Tokens**
+  - Returns tokens to a Token Issuer's pool of available tokens
+  - SPonsored by a Token Issuer

--- a/internal/chain/README.md
+++ b/internal/chain/README.md
@@ -1,8 +1,37 @@
 ## Chain Validator Design
 
-Chain validators are organized by transaction type. The executor handles mundane tasks that are common to all chain
-validators, such as authentication and authorization.
+Chain validators are organized by transaction type. The executor handles mundane
+tasks that are common to all chain validators, such as authentication and
+authorization.
 
-In general, every transaction requires a sponsor. Thus, the executor validates and loads the sponsor before delegating
-to the chain validator. However, certain transaction types, specifically synthetic transactions that create records, may
-not need an extant sponsor. The executor has a specific clause for these special cases.
+In general, every transaction requires a sponsor. Thus, the executor validates
+and loads the sponsor before delegating to the chain validator. However, certain
+transaction types, specifically synthetic transactions that create records, may
+not need an extant sponsor. The executor has a specific clause for these special
+cases.
+
+## Chain Validator Implementation
+
+Chain validators must satisfy the `TxExecutor` interface:
+
+```go
+type TxExecutor interface {
+	Type() types.TxType
+	Validate(*StateManager, *transactions.GenTransaction) error
+}
+```
+
+**All state manipulation (mutating and loading) must go through the state
+manager.** There are three methods that can be used to modify records and/or
+create synthetic transactions:
+
+- Implementing a user transaction executor
+  + `Update(record)` - Update one or more existing records. Cannot be used to
+    create records.
+  + `Create(record)` - Create one or more new records. Produces a synthetic
+    chain create transaction.
+  + `Submit(url, body)` - Submit a synthetic transaction.
+- Implementing a synthetic transaction executor
+  + `Update(record)` - Create or update one or more existing records.
+  + `Create(record)` - Cannot be used by synthetic transactions.
+  + `Submit(url, body)` - Cannot be used by synthetic transactions.

--- a/internal/chain/burn_tokens.go
+++ b/internal/chain/burn_tokens.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type BurnTokens struct{}
+
+func (BurnTokens) Type() types.TxType { return types.TxTypeBurnTokens }
+
+func (BurnTokens) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.BurnTokens)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	return errors.New("not implemented") // TODO
+}

--- a/internal/chain/create_data_account.go
+++ b/internal/chain/create_data_account.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type CreateDataAccount struct{}
+
+func (CreateDataAccount) Type() types.TxType { return types.TxTypeCreateDataAccount }
+
+func (CreateDataAccount) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.CreateDataAccount)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	return errors.New("not implemented") // TODO
+}

--- a/internal/chain/issue_tokens.go
+++ b/internal/chain/issue_tokens.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type IssueTokens struct{}
+
+func (IssueTokens) Type() types.TxType { return types.TxTypeIssueTokens }
+
+func (IssueTokens) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.IssueTokens)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	return errors.New("not implemented") // TODO
+}

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -203,6 +203,9 @@ func (m *StateManager) Create(record ...state.Chain) {
 
 // Submit queues a synthetic transaction for submission
 func (m *StateManager) Submit(url *url.URL, body encoding.BinaryMarshaler) {
+	if m.txType.IsSynthetic() {
+		panic("Called StateManager.Submit from a synthetic transaction!")
+	}
 	m.submissions = append(m.submissions, &submittedTx{url, body})
 }
 

--- a/internal/chain/synthetic_burn_tokens.go
+++ b/internal/chain/synthetic_burn_tokens.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type SyntheticBurnTokens struct{}
+
+func (SyntheticBurnTokens) Type() types.TxType { return types.TxTypeSyntheticBurnTokens }
+
+func (SyntheticBurnTokens) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.SyntheticBurnTokens)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	return errors.New("not implemented") // TODO
+}

--- a/internal/chain/synthetic_write_data.go
+++ b/internal/chain/synthetic_write_data.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type SyntheticWriteData struct{}
+
+func (SyntheticWriteData) Type() types.TxType { return types.TxTypeSyntheticWriteData }
+
+func (SyntheticWriteData) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.SyntheticWriteData)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	return errors.New("not implemented") // TODO
+}

--- a/internal/chain/write_data.go
+++ b/internal/chain/write_data.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type WriteData struct{}
+
+func (WriteData) Type() types.TxType { return types.TxTypeWriteData }
+
+func (WriteData) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.WriteData)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	return errors.New("not implemented") // TODO
+}

--- a/internal/chain/write_data_to.go
+++ b/internal/chain/write_data_to.go
@@ -1,0 +1,24 @@
+package chain
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type WriteDataTo struct{}
+
+func (WriteDataTo) Type() types.TxType { return types.TxTypeWriteDataTo }
+
+func (WriteDataTo) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.WriteDataTo)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	return errors.New("not implemented") // TODO
+}

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -207,3 +207,64 @@ DirectoryQueryResult:
     type: slice
     slice:
       type: string
+
+DataAccount:
+  kind: chain
+  fields:
+  - name: Data
+    type: bytes
+
+LiteDataAccount:
+  kind: chain
+  fields:
+  - name: Data
+    type: bytes
+
+CreateDataAccount:
+  kind: tx
+  fields:
+  - name: Url
+    type: string
+    is-url: true
+
+WriteData:
+  kind: tx
+  fields:
+  - name: Data
+    type: bytes
+
+WriteDataTo:
+  kind: tx
+  fields:
+  - name: Recipient
+    type: string
+    is-url: true
+  - name: Data
+    type: bytes
+
+IssueTokens:
+  kind: tx
+  fields:
+  - name: Recipient
+    type: string
+    is-url: true
+  - name: Amount
+    type: bigint
+
+BurnTokens:
+  kind: tx
+  fields:
+  - name: Amount
+    type: bigint
+
+SyntheticWriteData:
+  kind: tx
+  fields:
+  - name: Data
+    type: bytes
+
+SyntheticBurnTokens:
+  kind: tx
+  fields:
+  - name: Amount
+    type: bigint

--- a/types/chain_types.go
+++ b/types/chain_types.go
@@ -17,6 +17,9 @@ const (
 )
 
 const (
+	// ChainTypeAnchor is one or more Merkle DAG anchors.
+	ChainTypeAnchor ChainType = 1
+
 	// ChainTypeIdentity is an Identity chain, aka an ADI.
 	ChainTypeIdentity ChainType = 2
 
@@ -44,9 +47,11 @@ const (
 	// ChainTypeKeyBook is a key book chain.
 	ChainTypeKeyBook ChainType = 10
 
-	// TODO Directory node anchor chain?
+	// ChainTypeDataAccount is an ADI Data Account chain.
+	ChainTypeDataAccount ChainType = 11
 
-	// TODO Block validator node anchor chain?
+	// ChainTypeLiteDataAccount is a Lite Data Account chain.
+	ChainTypeLiteDataAccount ChainType = 12
 )
 
 // ID returns the chain type ID

--- a/types/transaction_types.go
+++ b/types/transaction_types.go
@@ -38,9 +38,29 @@ const (
 	// produces a synthetic deposit tokens transaction.
 	TxTypeWithdrawTokens TransactionType = 0x03
 
+	// TxTypeCreateDataAccount creates an ADI Data Account, which produces a
+	// synthetic chain create transaction.
+	TxTypeCreateDataAccount TransactionType = 0x04
+
+	// TxTypeWriteData writes data to an ADI Data Account, which *does not*
+	// produce a synthetic transaction.
+	TxTypeWriteData TransactionType = 0x05
+
+	// TxTypeWriteDataTo writes data to a Lite Data Account, which produces a
+	// synthetic write data transaction.
+	TxTypeWriteDataTo TransactionType = 0x06
+
 	// TxTypeCreateToken creates a token issuer, which produces a synthetic
 	// chain create transaction.
 	TxTypeCreateToken TransactionType = 0x08
+
+	// TxTypeIssueTokens issues tokens to a token account, which produces a
+	// synthetic token deposit transaction.
+	TxTypeIssueTokens TransactionType = 0x09
+
+	// TxTypeBurnTokens burns tokens from a token account, which produces a
+	// synthetic burn tokens transaction.
+	TxTypeBurnTokens TransactionType = 0x0A
 
 	// TxTypeCreateKeyPage creates a key page, which produces a synthetic chain
 	// create transaction.
@@ -64,11 +84,18 @@ const (
 	// TxTypeSyntheticCreateChain creates or updates chains.
 	TxTypeSyntheticCreateChain TransactionType = 0x31
 
+	// TxTypeSyntheticWriteData writes data to a data account.
+	TxTypeSyntheticWriteData TransactionType = 0x32
+
 	// TxTypeSyntheticDepositTokens deposits tokens into token accounts.
 	TxTypeSyntheticDepositTokens TransactionType = 0x33
 
 	// TxTypeSyntheticDepositCredits deposits credits into a credit holder.
 	TxTypeSyntheticDepositCredits TransactionType = 0x35
+
+	// TxTypeSyntheticBurnTokens returns tokens to a token issuer's pool of
+	// issuable tokens.
+	TxTypeSyntheticBurnTokens TransactionType = 0x36
 
 	// TxTypeSyntheticGenesis initializes system chains.
 	TxTypeSyntheticGenesis TransactionType = 0x37


### PR DESCRIPTION
Adds most of the remaining chain and transaction types and stubs out the corresponding transaction validators.

No functional changes (since none of the transactions can actually be executed).