### PR TITLE
chore: Ac 519 tx output

### DIFF
--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -117,7 +117,7 @@ func GetTXHistory(accountUrl string, s string, e string) {
 		log.Fatal(err)
 	}
 
-	var res acmeapi.APIDataResponse
+	var res acmeapi.APIDataResponsePagination
 
 	params := new(acmeapi.APIRequestURLPagination)
 	params.URL = types.String(u.String())
@@ -134,8 +134,9 @@ func GetTXHistory(accountUrl string, s string, e string) {
 		PrintJsonRpcError(err)
 	}
 
-	PrintQueryResponse(&res)
-
+	for i := range res.Data {
+		PrintQueryResponse(res.Data[i])
+	}
 }
 
 func CreateTX(sender string, args []string) {

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"os"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"time"
 
@@ -79,7 +79,7 @@ func PrintTX() {
 
 func GetTX(hash string) {
 
-	var res interface{}
+	var res acmeapi.APIDataResponse
 	var str []byte
 	var hashbytes types.Bytes32
 
@@ -88,7 +88,6 @@ func GetTX(hash string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	params.Hash = hashbytes
 
 	data, err := json.Marshal(params)
@@ -101,12 +100,9 @@ func GetTX(hash string) {
 		PrintJsonRpcError(err)
 	}
 
-	str, err = json.Marshal(res)
-	if err != nil {
-		log.Fatal(err)
-	}
+	PrintQueryResponse(&res)
 
-	fmt.Fprintf(os.Stderr, string(str))
+	//fmt.Fprintf(os.Stderr, string(str))
 }
 
 func GetTXHistory(accountUrl string, s string, e string) {

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"time"
 
@@ -80,7 +79,6 @@ func PrintTX() {
 func GetTX(hash string) {
 
 	var res acmeapi.APIDataResponse
-	var str []byte
 	var hashbytes types.Bytes32
 
 	params := new(acmeapi.TokenTxRequest)
@@ -101,8 +99,6 @@ func GetTX(hash string) {
 	}
 
 	PrintQueryResponse(&res)
-
-	//fmt.Fprintf(os.Stderr, string(str))
 }
 
 func GetTXHistory(accountUrl string, s string, e string) {
@@ -121,8 +117,7 @@ func GetTXHistory(accountUrl string, s string, e string) {
 		log.Fatal(err)
 	}
 
-	var res interface{}
-	var str []byte
+	var res acmeapi.APIDataResponse
 
 	params := new(acmeapi.APIRequestURLPagination)
 	params.URL = types.String(u.String())
@@ -139,12 +134,7 @@ func GetTXHistory(accountUrl string, s string, e string) {
 		PrintJsonRpcError(err)
 	}
 
-	str, err = json.Marshal(res)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Fprintf(os.Stderr, string(str))
+	PrintQueryResponse(&res)
 
 }
 

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -246,7 +246,7 @@ type ActionResponse struct {
 func (a *ActionResponse) Print() {
 	if WantJsonOutput {
 		if a.Code == "0" || a.Code == "" {
-			 a.Code = "ok"
+			a.Code = "ok"
 		}
 		dump, err := json.Marshal(a)
 		if err != nil {
@@ -334,7 +334,7 @@ func formatAmount(tokenUrl string, amount *big.Int) (string, error) {
 	bal := big.Float{}
 	bal.Quo(&bf, &bd)
 
-	return bal.String(),nil
+	return fmt.Sprintf("%s %s", bal.String(), t.Symbol), nil
 }
 
 func PrintQueryResponse(res *acmeapi.APIDataResponse) {
@@ -390,11 +390,14 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 				log.Fatal(err)
 			}
 
-			amt := formatAmount(ata.TokenUrl, &ata.Balance.Int)
+			amt, err := formatAmount(ata.TokenUrl, &ata.Balance.Int)
+			if err != nil {
+				amt = "unknown"
+			}
 			var out string
 			out += fmt.Sprintf("\n\tAccount Url\t:\t%v\n", ata.Url)
 			out += fmt.Sprintf("\tToken Url\t:\t%v\n", ata.TokenUrl)
-			out += fmt.Sprintf("\tBalance\t\t:\t%s %s\n", bal.String(), t.Symbol)
+			out += fmt.Sprintf("\tBalance\t\t:\t%s %s\n", amt)
 			out += fmt.Sprintf("\tKey Book Url\t:\t%s\n", ata.KeyBookUrl)
 
 			log.Fatal(out)
@@ -490,24 +493,24 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 			}
 			log.Fatal(out)
 		case "tokenTx":
-
 			tx := acmeapi.TokenTx{}
-			err := json.Unmarshal(*res.Data,&tx)
+			err := json.Unmarshal(*res.Data, &tx)
 			if err != nil {
 				log.Fatalf("Cannot extract token transaction data from request")
 			}
-			//str, err := json.Marshal(res)
-			//if err != nil {
-			//	log.Fatal(err)
-			//}
-			//fmt.
 
-			out := fmt.Sprintf("From\t:%s", tx.From)
+			out := "\n"
 			for i := range tx.To {
-				out += fmt.Sprintf("To\t:%stx.To[i]
+				bi := big.Int{}
+				bi.SetInt64(int64(tx.To[i].Amount))
+				amt, err := formatAmount("acc://ACME", &bi)
+				if err != nil {
+					amt = "unknown"
+				}
+				out += fmt.Sprintf("Send %s from %s to %s\n", amt, tx.From.String, tx.To[i].URL.String)
 			}
-			out += fmt.Sprintf(")
-
+			log.Fatal(out)
+		case "tokenAccountHistory":
 		default:
 
 		}

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -311,8 +311,33 @@ var (
 	}
 )
 
-func PrintQueryResponse(res *acmeapi.APIDataResponse) {
+func formatAmount(tokenUrl string, amount *big.Int) (string, error) {
 
+	//query the token
+	tokenData := Get(tokenUrl)
+	r := acmeapi.APIDataResponse{}
+	err := json.Unmarshal([]byte(tokenData), &r)
+	if err != nil {
+		return "", err
+	}
+
+	t := response.Token{}
+	err = json.Unmarshal(*r.Data, &t)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bf := big.Float{}
+	bd := big.Float{}
+	bd.SetFloat64(math.Pow(10.0, float64(t.Precision)))
+	bf.SetInt(amount)
+	bal := big.Float{}
+	bal.Quo(&bf, &bd)
+
+	return bal.String(),nil
+}
+
+func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 	if WantJsonOutput {
 		data, err := json.Marshal(res)
 		if err != nil {
@@ -365,27 +390,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 				log.Fatal(err)
 			}
 
-			//query the token
-			tokenData := Get(ata.TokenUrl)
-			r := acmeapi.APIDataResponse{}
-			err = json.Unmarshal([]byte(tokenData), &r)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			t := response.Token{}
-			err = json.Unmarshal(*r.Data, &t)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			bf := big.Float{}
-			bd := big.Float{}
-			bd.SetFloat64(math.Pow(10.0, float64(t.Precision)))
-			bf.SetInt(&ata.Balance.Int)
-			bal := big.Float{}
-			bal.Quo(&bf, &bd)
-
+			amt := formatAmount(ata.TokenUrl, &ata.Balance.Int)
 			var out string
 			out += fmt.Sprintf("\n\tAccount Url\t:\t%v\n", ata.Url)
 			out += fmt.Sprintf("\tToken Url\t:\t%v\n", ata.TokenUrl)
@@ -484,6 +489,27 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 				out += fmt.Sprintf("\t%d\t%d\t%x\t%s", i, k.Nonce, k.PublicKey, keyName)
 			}
 			log.Fatal(out)
+		case "tokenTx":
+
+			tx := acmeapi.TokenTx{}
+			err := json.Unmarshal(*res.Data,&tx)
+			if err != nil {
+				log.Fatalf("Cannot extract token transaction data from request")
+			}
+			//str, err := json.Marshal(res)
+			//if err != nil {
+			//	log.Fatal(err)
+			//}
+			//fmt.
+
+			out := fmt.Sprintf("From\t:%s", tx.From)
+			for i := range tx.To {
+				out += fmt.Sprintf("To\t:%stx.To[i]
+			}
+			out += fmt.Sprintf(")
+
+		default:
+
 		}
 	}
 }

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -6,9 +6,11 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"github.com/AccumulateNetwork/accumulate/types/synthetic"
 	"log"
 	"math"
 	"math/big"
+	"os"
 	"strconv"
 	"time"
 
@@ -337,14 +339,28 @@ func formatAmount(tokenUrl string, amount *big.Int) (string, error) {
 	return fmt.Sprintf("%s %s", bal.String(), t.Symbol), nil
 }
 
+func printGeneralTransactionParameters(res *acmeapi.APIDataResponse) string {
+	out := fmt.Sprintf("---\n")
+	out += fmt.Sprintf("  - Transaction           : %x\n", res.TxId.AsBytes32())
+	out += fmt.Sprintf("  - Merkle DAG Root       : %x\n", res.MDRoot.AsBytes32())
+	out += fmt.Sprintf("  - Signer Url            : %s\n", res.Sponsor)
+	out += fmt.Sprintf("  - Signature             : %x\n", res.Sig.Bytes())
+	out += fmt.Sprintf("  - Signer Key            : %x\n", res.Signer.PublicKey.Bytes())
+	out += fmt.Sprintf("  - Signer Nonce          : %d\n", res.Signer.Nonce)
+	out += fmt.Sprintf("  - Key Page              : %d (height) / %d (index)\n", res.KeyPage.Height, res.KeyPage.Index)
+	out += fmt.Sprintf("===\n")
+	return out
+}
+
 func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 	if WantJsonOutput {
 		data, err := json.Marshal(res)
 		if err != nil {
 			log.Fatal(err)
 		}
-		log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
-		log.Fatal(string(data))
+		//log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+		//log.Fatal(string(data))
+		fmt.Fprintf(os.Stderr, string(data))
 	} else {
 		switch res.Type {
 		case "anonTokenAccount":
@@ -381,8 +397,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 			out += fmt.Sprintf("\tCredits\t\t:\t%s\n", ata.CreditBalance.String())
 			out += fmt.Sprintf("\tNonce\t\t:\t%d\n", ata.Nonce)
 
-			log.Fatal(out)
-
+			fmt.Fprintf(os.Stderr, string(out))
 		case "tokenAccount":
 			ata := response.TokenAccount{}
 			err := json.Unmarshal(*res.Data, &ata)
@@ -400,7 +415,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 			out += fmt.Sprintf("\tBalance\t\t:\t%s %s\n", amt)
 			out += fmt.Sprintf("\tKey Book Url\t:\t%s\n", ata.KeyBookUrl)
 
-			log.Fatal(out)
+			fmt.Fprintf(os.Stderr, string(out))
 		case "adi":
 			adi := response.ADI{}
 			err := json.Unmarshal(*res.Data, &adi)
@@ -412,7 +427,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 			out += fmt.Sprintf("\n\tADI Url\t\t:\t%v\n", adi.Url)
 			out += fmt.Sprintf("\tKey Book Url\t:\t%s\n", adi.KeyBookName)
 
-			log.Fatal(out)
+			fmt.Fprintf(os.Stderr, string(out))
 		case "directory":
 			dqr := protocol.DirectoryQueryResult{}
 			err := json.Unmarshal(*res.Data, &dqr)
@@ -434,7 +449,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 				}
 				out += fmt.Sprintf("\t%v (%s)\n", s, chainType)
 			}
-			log.Fatal(out)
+			fmt.Fprintf(os.Stderr, string(out))
 		case "sigSpecGroup":
 			//workaround for protocol unmarshaling bug
 			var ssg struct {
@@ -474,7 +489,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 				s := resolveKeyPageUrl(u.Authority, v[:])
 				out += fmt.Sprintf("\t%d\t:\t%s\n", i+1, s)
 			}
-			log.Fatal(out)
+			fmt.Fprintf(os.Stderr, string(out))
 		case "sigSpec":
 			ss := protocol.SigSpec{}
 			err := json.Unmarshal(*res.Data, &ss)
@@ -491,26 +506,47 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 				}
 				out += fmt.Sprintf("\t%d\t%d\t%x\t%s", i, k.Nonce, k.PublicKey, keyName)
 			}
-			log.Fatal(out)
+			fmt.Fprintf(os.Stderr, string(out))
 		case "tokenTx":
-			tx := acmeapi.TokenTx{}
+			tx := response.TokenTx{}
 			err := json.Unmarshal(*res.Data, &tx)
 			if err != nil {
 				log.Fatalf("Cannot extract token transaction data from request")
 			}
 
-			out := "\n"
-			for i := range tx.To {
+			var out string
+			for i := range tx.ToAccount {
 				bi := big.Int{}
-				bi.SetInt64(int64(tx.To[i].Amount))
+				bi.SetInt64(int64(tx.ToAccount[i].Amount))
 				amt, err := formatAmount("acc://ACME", &bi)
 				if err != nil {
 					amt = "unknown"
 				}
-				out += fmt.Sprintf("Send %s from %s to %s\n", amt, tx.From.String, tx.To[i].URL.String)
+				out += fmt.Sprintf("Send %s from %s to %s\n", amt, *tx.From.AsString(), tx.ToAccount[i].URL.String)
+				out += fmt.Sprintf("  - Synthetic Transaction : %x\n", tx.ToAccount[i].SyntheticTxId)
 			}
-			log.Fatal(out)
-		case "tokenAccountHistory":
+
+			out += printGeneralTransactionParameters(res)
+			fmt.Fprintf(os.Stderr, string(out))
+		case "syntheticTokenDeposit":
+			deposit := synthetic.TokenTransactionDeposit{}
+			err := json.Unmarshal(*res.Data, &deposit)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			out := "\n"
+			amt, err := formatAmount(*deposit.TokenUrl.AsString(), &deposit.DepositAmount.Int)
+			if err != nil {
+				amt = "unknown"
+			}
+			out += fmt.Sprintf("Receive %s from %s to %s\n", amt, *deposit.FromUrl.AsString(),
+				*deposit.ToUrl.AsString())
+
+			out += printGeneralTransactionParameters(res)
+			fmt.Fprintf(os.Stderr, string(out))
+
 		default:
 
 		}

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -412,7 +412,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) {
 			var out string
 			out += fmt.Sprintf("\n\tAccount Url\t:\t%v\n", ata.Url)
 			out += fmt.Sprintf("\tToken Url\t:\t%v\n", ata.TokenUrl)
-			out += fmt.Sprintf("\tBalance\t\t:\t%s %s\n", amt)
+			out += fmt.Sprintf("\tBalance\t\t:\t%s\n", amt)
 			out += fmt.Sprintf("\tKey Book Url\t:\t%s\n", ata.KeyBookUrl)
 
 			fmt.Fprintf(os.Stderr, string(out))

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -326,7 +326,7 @@ func formatAmount(tokenUrl string, amount *big.Int) (string, error) {
 	t := response.Token{}
 	err = json.Unmarshal(*r.Data, &t)
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 
 	bf := big.Float{}


### PR DESCRIPTION
- cleaned up human-readable output for tokenTx and syntheticTokenDeposit

output can be viewed by 

mishmash of receive and send token transactions
./cli tx history acc://7117c50f04f1254d56b704dc05298912deeb25dbc1d26ef6/ACME 0 10

receive tokens transaction example:
./cli tx get a5bea9be9885c5b71e8018f4391ea669d9b49bc41766e8b5f38e44b4c0abb720

send tokens transaction example:
./cli tx get 494aee6c6e7129450dd6086d720443592411673a22b05422325775ff77a1eb3c
