### PR TITLE
feat(smt): support non-hash data in merkle trees

### DIFF
--- a/smt/managed/blockIndex.go
+++ b/smt/managed/blockIndex.go
@@ -78,7 +78,7 @@ func EndBlock(manager *MerkleManager, cID []byte, blockIndex uint64) error {
 	b.BlockIndex = uint64(manager.MS.Count)
 
 	data := b.Marshal()
-	blkIdxHash := [32]byte(manager.MS.HashFunction(data))
+	blkIdxHash := manager.MS.HashFunction(data)
 	manager.AddHash(blkIdxHash)
 	manager.Manager.Key(blkIdxHash).PutBatch(data)
 

--- a/smt/managed/hash_test.go
+++ b/smt/managed/hash_test.go
@@ -10,7 +10,7 @@ func TestHash(t *testing.T) {
 	var h Hash
 	var data = []byte("abc")
 	hf := func(data []byte) Hash {
-		return sha256.Sum256(data)
+		return Sha256(data)
 	}
 	h = hf([]byte(data))
 	h2 := h.Copy()
@@ -22,16 +22,5 @@ func TestHash(t *testing.T) {
 	result := sha256.Sum256(append(h3[:], h3[:]...))
 	if !bytes.Equal(h[:], result[:]) {
 		t.Error("combine failed")
-	}
-	ph := h.CopyAndPoint()
-	if !bytes.Equal(ph[:], h[:]) {
-		t.Error("fail CopyAndPoint")
-	}
-	h[0] ^= 1
-	if bytes.Equal(ph[:], h[:]) {
-		t.Error("fail CopyAndPoint2")
-	}
-	if !bytes.Equal(h[:], h.Bytes()) {
-		t.Error("fail Bytes()")
 	}
 }

--- a/smt/managed/merklemanager.go
+++ b/smt/managed/merklemanager.go
@@ -23,31 +23,37 @@ type MerkleManager struct {
 // AddHash
 // Add a Hash to the Chain controlled by the ChainManager
 func (m *MerkleManager) AddHash(hash Hash) {
+	hash = hash.Copy() // Just to make sure hash doesn't get changed
+
 	// Keep the index of every element added to the Merkle Tree, but only of the first instance
-	i, err := m.GetElementIndex(hash[:])
+	i, err := m.GetElementIndex(hash)
 	_ = i
 	if errors.Is(err, storage.ErrNotFound) { // So only if the hash is not yet added to the Merkle Tree
-		m.Manager.Key(m.cid, "ElementIndex", hash[:]).PutBatch(common.Int64Bytes(m.MS.Count)) // Keep its index
-		m.Manager.Key(m.cid, "Element", m.MS.Count).PutBatch(hash[:])
+		m.Manager.Key(m.cid, "ElementIndex", hash).PutBatch(common.Int64Bytes(m.MS.Count)) // Keep its index
+		m.Manager.Key(m.cid, "Element", m.MS.Count).PutBatch(hash)
 	}
 
 	switch m.MS.Count & m.MarkMask { // Mask to the bits counting up to a mark.
 	case m.MarkMask: // This is the case just before rolling into a Mark (all bits set. +1 more will be zero)
 
-		MSCount := common.Int64Bytes(m.MS.Count) // Get the current index as a varInt
-		MSState, err := m.MS.Marshal()           // Get the current state
-		if err != nil {                          // Panic if we cannot, because that should never happen.
+		MSState, err := m.MS.Marshal() // Get the current state
+		if err != nil {                // Panic if we cannot, because that should never happen.
 			panic(fmt.Sprintf("could not marshal MerkleState: %v", err)) //
 		}
 
-		m.Manager.Key(m.cid, "States", MSCount).PutBatch(MSState)      //     Save Merkle State at n*MarkFreq-1
-		m.Manager.Key(m.cid, "NextElement", MSCount).PutBatch(hash[:]) //     Save Hash added at n*MarkFreq-1
+		count := m.MS.Count
+		m.Manager.Key(m.cid, "States", count).PutBatch(MSState)   //     Save Merkle State at n*MarkFreq-1
+		m.Manager.Key(m.cid, "NextElement", count).PutBatch(hash) //     Save Hash added at n*MarkFreq-1
 
 		m.MS.AddToMerkleTree(hash) //                                  Add the hash to the Merkle Tree
 
-		state, err := m.MS.Marshal()                            // Create the marshaled Merkle State
-		m.Manager.Key(m.cid, "States", MSCount).PutBatch(state) // Save Merkle State at n*MarkFreq
-		m.MS.HashList = m.MS.HashList[:0]                       // We need to clear the HashList first
+		// TODO This overwrites the states entry. Either it should write to
+		// `m.MS.Count` instead of `count` or the previous write should be
+		// removed.
+
+		state, err := m.MS.Marshal()                          // Create the marshaled Merkle State
+		m.Manager.Key(m.cid, "States", count).PutBatch(state) // Save Merkle State at n*MarkFreq
+		m.MS.HashList = m.MS.HashList[:0]                     // We need to clear the HashList first
 
 	default: // This is the case of not rolling into a mark; Just add the hash to the Merkle Tree
 		m.MS.AddToMerkleTree(hash) //                                      Always add to the merkle tree
@@ -198,6 +204,9 @@ func (m *MerkleManager) GetState(element int64) *MerkleState {
 	if e != nil {                                            // If nil, there is no state saved
 		return nil //                                                   return nil, as no state exists
 	}
+	if element == 15 {
+		// fmt.Printf("GetState %d %X\n", element, data)
+	}
 	ms := new(MerkleState)                     //                                 Get a fresh new MerkleState
 	if err := ms.UnMarshal(data); err != nil { //                                 set it the MerkleState
 		panic(fmt.Sprintf("corrupted database; invalid state. error: %v", err)) // panic if the database is corrupted.
@@ -207,14 +216,12 @@ func (m *MerkleManager) GetState(element int64) *MerkleState {
 
 // GetNext
 // Get the next hash to be added to a state at this height
-func (m *MerkleManager) GetNext(element int64) (hash *Hash) {
+func (m *MerkleManager) GetNext(element int64) (hash Hash) {
 	data, err := m.Manager.Key(m.cid, "NextElement", element).Get()
 	if err != nil || len(data) != storage.KeyLength {
 		return nil
 	}
-	hash = new(Hash)
-	copy(hash[:], data)
-	return hash
+	return Hash(data).Copy()
 }
 
 // AddHashString
@@ -223,8 +230,6 @@ func (m *MerkleManager) AddHashString(hash string) {
 	if h, err := hex.DecodeString(hash); err != nil { //                             Convert to a binary slice
 		panic(fmt.Sprintf("failed to decode a hash %s with error %v", hash, err)) // If this fails, panic; no recovery
 	} else {
-		var h2 [32]byte // Make the slice into a 32 byte array
-		copy(h2[:], h)  // copy the data
-		m.AddHash(h2)   // Add the hash
+		m.AddHash(h) // Add the hash
 	}
 }

--- a/smt/managed/merklemanager_test.go
+++ b/smt/managed/merklemanager_test.go
@@ -23,7 +23,7 @@ func TestMerkleManager_ReadChainHead(t *testing.T) {
 	MM1.SetChainID([]byte{1})
 
 	for i := 0; i < 100; i++ {
-		MM1.AddHash(sha256.Sum256([]byte{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}))
+		MM1.AddHash(Sha256([]byte{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}))
 		err1 := MM1.WriteChainHead([]byte{1})
 		if err1 != nil {
 			t.Fatalf("didn't write chain head")
@@ -64,7 +64,7 @@ func TestIndexing2(t *testing.T) {
 	for i := 0; i < testlen; i++ {
 		data := []byte(fmt.Sprintf("data %d", i))
 		dataHash := sha256.Sum256(data)
-		MM1.AddHash(dataHash)
+		MM1.AddHash(dataHash[:])
 		dataI, e := MM1.Manager.Key(Chain, "ElementIndex", dataHash).Get()
 		if e != nil {
 			t.Fatalf("error")
@@ -108,7 +108,7 @@ func TestMerkleManager(t *testing.T) {
 	// Fill the Merkle Tree with a few hashes
 	hash := sha256.Sum256([]byte("start"))
 	for i := 0; i < testLen; i++ {
-		MM1.AddHash(hash)
+		MM1.AddHash(hash[:])
 		hash = sha256.Sum256(hash[:])
 	}
 

--- a/smt/managed/merklemanagerrange_test.go
+++ b/smt/managed/merklemanagerrange_test.go
@@ -12,8 +12,9 @@ func b2i(b Hash) int64 {
 	return i
 }
 
-func i2b(i int64) [32]byte {
-	return [32]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
+func i2b(i int64) []byte {
+	b := [32]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
+	return b[:]
 }
 
 func TestConversions(t *testing.T) {
@@ -50,9 +51,7 @@ func TestMerkleManager_GetRange(t *testing.T) {
 		h := i2b(i)
 		MM1.AddHash(h)
 		iCnt, err := MM1.GetElementIndex(h[:])
-		if err != nil {
-			t.Fatal("failed to get the index of a hash")
-		}
+		require.NoError(t, err, "failed to get the index of a hash")
 		require.True(t, i == iCnt, "should get back what we set")
 
 	}

--- a/smt/managed/merklemanagerrestart_test.go
+++ b/smt/managed/merklemanagerrestart_test.go
@@ -1,7 +1,6 @@
 package managed
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -36,7 +35,7 @@ func TestRestart(t *testing.T) {
 				}
 			}
 			for rand.Int()%30 > 0 { //                                       Add 0 or more random hashes
-				MM1.AddHash(sha256.Sum256(common.Int64Bytes(rand.Int63()))) // Generate and add one random hash
+				MM1.AddHash(Sha256(common.Int64Bytes(rand.Int63()))) // Generate and add one random hash
 			}
 		}
 	}
@@ -51,7 +50,7 @@ func RandInt() uint64 {
 	return seed<<11 ^ seed>>5
 }
 func RandHash() Hash {
-	return sha256.Sum256(common.Uint64Bytes(RandInt()))
+	return Sha256(common.Uint64Bytes(RandInt()))
 }
 
 func TestRand(t *testing.T) {
@@ -94,7 +93,7 @@ func TestRestartCache(t *testing.T) {
 			t.Errorf("did not create a merkle manager: %v", err) //  won't get one unless something is really sick
 		}
 
-		var cached [][32]byte // Using this slice to track the hashes that have been written to MM1
+		var cached [][]byte // Using this slice to track the hashes that have been written to MM1
 		//                       but not yet written to disk by MM1.  Calling EndBatch on MM1 will need to
 		//                       clear this cache.
 	TestLoop:
@@ -129,6 +128,7 @@ func TestRestartCache(t *testing.T) {
 				}
 
 				if !MM1.MS.Equal(MM2.MS) { // MM2 should be the same as MM1
+					MM1.MS.Equal(MM2.MS)
 					t.Errorf("MM2 isn't tracking MM1 at index: %d %d", i, j) // are going to be messed up.
 				}
 				break TestLoop

--- a/smt/managed/receipt.go
+++ b/smt/managed/receipt.go
@@ -2,14 +2,13 @@ package managed
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"fmt"
 	"math"
 )
 
 type Node struct {
 	Right bool
-	Hash  [32]byte
+	Hash  Hash
 }
 
 // Receipt
@@ -50,8 +49,8 @@ func GetElementState(
 		nextMark = manager.MS.Copy() //                        then just use the last state of the Merkle Tree
 	}
 	for i, v1 := range nextMark.HashList { //                Go through the pending elements
-		nextMarkIndex = int64(i) //                           Return location in this HashList for next step
-		if v1 == element {       //                           If the element is found
+		nextMarkIndex = int64(i)      //                           Return location in this HashList for next step
+		if bytes.Equal(v1, element) { //                           If the element is found
 			return currentState, nextMark, height, int64(i) // Return location so following code can reuse it
 		}
 		currentState.AddToMerkleTree(v1) //                   Otherwise, just add value to merkle tree and keep looking
@@ -116,7 +115,7 @@ func (r *Receipt) AdvanceMarkToMark(manager *MerkleManager, anchorState, current
 	// markNext is the next element to be added to the Merkle Tree.  It WILL carry into height, so
 	// we have to use AddAHash to add its contribution to the receipt.
 	markNext := manager.GetNext(currentState.Count + markStep - 1) // Get the the next element
-	height = r.AddAHash(currentState, height, true, *markNext)     // Record its impact on the receipt
+	height = r.AddAHash(currentState, height, true, markNext)      // Record its impact on the receipt
 	// Handle the special case where the Mark we jump to == the AnchorState
 	if currentState.Count == anchorState.Count {
 		return true, height
@@ -152,7 +151,7 @@ func (r *Receipt) AddAHash(
 			if Right {
 				node.Hash = v1
 			} else {
-				node.Hash = *v2
+				node.Hash = v2
 			}
 			//fmt.Printf("Height %3d %x\n", Height, node.Hash)
 			// v1 becomes HashOf(pending[j]+v1)
@@ -166,15 +165,14 @@ func (r *Receipt) AddAHash(
 }
 
 func (r *Receipt) ComputeDag(manager *MerkleManager, currentState *MerkleState, height int, right bool) {
-	var anchor *Hash
+	var anchor Hash
 	for i, v := range currentState.Pending {
 		if v == nil { // if v is nil, there is nothing to do regardless. Note i cannot == Height
 			continue // because the previous code tracks Height such that there is always a value.
 		}
 		if anchor == nil { // Find the first non nil in pending
-			anchor = new(Hash) // Make an anchor
-			*anchor = *v       // copy over the value of v (which is never nil
-			if i == height {   // Note that there is no way this code does not
+			anchor = v.Copy() // Copy the anchor
+			if i == height {  // Note that there is no way this code does not
 				right = false //      execute before the following code that adds
 			} else { //               applyHash records to the receipt
 				right = true
@@ -186,15 +184,14 @@ func (r *Receipt) ComputeDag(manager *MerkleManager, currentState *MerkleState, 
 			r.Nodes = append(r.Nodes, node)
 			node.Right = right // We record if the proof path is in the anchor
 			if right {         // or in the pending array
-				node.Hash = *anchor
+				node.Hash = anchor
 			} else {
-				node.Hash = *v
+				node.Hash = v
 			}
 			// Note once the object derivative is in anchor, it never leaves. All combining
 			right = false // then comes from the left
 			// Combine all the pending hash values into the anchor
-			hash := currentState.HashFunction(append((*v)[:], (*anchor)[:]...))
-			anchor = &hash
+			anchor = v.Combine(currentState.HashFunction, anchor)
 		}
 	}
 	// We are testing anchor, but it can't be nil
@@ -202,7 +199,7 @@ func (r *Receipt) ComputeDag(manager *MerkleManager, currentState *MerkleState, 
 		panic("anchor was nil, and this should not be possible.")
 	}
 	// Put the resulting anchor into the receipt
-	r.Anchor = *anchor
+	r.Anchor = anchor
 }
 
 // String
@@ -216,9 +213,9 @@ func (r *Receipt) String() string {
 		r := "L"
 		if v.Right {
 			r = "R"
-			working = sha256.Sum256(append(working[:], v.Hash[:]...))
+			working = Sha256(append(working[:], v.Hash[:]...))
 		} else {
-			working = sha256.Sum256(append(v.Hash[:], working[:]...))
+			working = Sha256(append(v.Hash[:], working[:]...))
 		}
 		b.WriteString(fmt.Sprintf(" %10d Apply %s %x working: %x \n", i, r, v.Hash, working))
 	}
@@ -276,15 +273,15 @@ func (r Receipt) Validate() bool {
 	// Now apply all the path hashes to the anchor
 	for _, node := range r.Nodes {
 		// Need a [32]byte to slice
-		hash := [32]byte(node.Hash)
+		hash := node.Hash
 		if node.Right {
 			// If this hash comes from the right, apply it that way
-			anchor = sha256.Sum256(append(anchor[:], hash[:]...))
+			anchor = anchor.Combine(Sha256, hash)
 		} else {
 			// If this hash comes from the left, apply it that way
-			anchor = sha256.Sum256(append(hash[:], anchor[:]...))
+			anchor = hash.Combine(Sha256, anchor)
 		}
 	}
 	// In the end, anchor should be the same hash the receipt expects.
-	return anchor == r.Anchor
+	return anchor.Equal(r.Anchor)
 }

--- a/smt/managed/receipt_test.go
+++ b/smt/managed/receipt_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func GetHash(i int) Hash {
-	return sha256.Sum256([]byte(fmt.Sprint(i)))
+	return Sha256([]byte(fmt.Sprint(i)))
 }
 
 func TestReceipt(t *testing.T) {

--- a/smt/storage/database/manager_test.go
+++ b/smt/storage/database/manager_test.go
@@ -1,4 +1,4 @@
-package database_test
+package database
 
 import (
 	"bytes"
@@ -11,14 +11,13 @@ import (
 	"testing"
 
 	"github.com/AccumulateNetwork/accumulate/smt/common"
-	"github.com/AccumulateNetwork/accumulate/smt/storage/database"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
 
 func TestDBManager_TransactionsBadger(t *testing.T) {
 
-	dbManager := new(database.Manager)
+	dbManager := new(Manager)
 
 	dir, err := ioutil.TempDir("", "badger")
 	if err != nil {
@@ -39,7 +38,7 @@ func TestDBManager_TransactionsBadger(t *testing.T) {
 
 func TestDBManager_TransactionsMemory(t *testing.T) {
 
-	dbManager := new(database.Manager)
+	dbManager := new(Manager)
 	_ = dbManager.Init("memory", "")
 	writeAndReadBatch(t, dbManager)
 	writeAndRead(t, dbManager)
@@ -53,13 +52,13 @@ func randSHA() [32]byte {
 	return sha256.Sum256(b[:])
 }
 
-func writeAndReadBatch(t *testing.T, dbManager *database.Manager) {
+func writeAndReadBatch(t *testing.T, dbManager *Manager) {
 	const cnt = 10 // how many test values used
 
 	// Buckets are "a" "b" and "c"
 
 	type ent struct { // Keep a history
-		Key   database.KeyRef
+		Key   KeyRef
 		Value []byte
 	}
 	var submissions []ent // Every key/value submitted goes here, in order
@@ -75,8 +74,8 @@ func writeAndReadBatch(t *testing.T, dbManager *database.Manager) {
 	for i := byte(0); i < cnt; i++ {
 		add()
 		for i, pair := range submissions {
-			require.NotNil(t, dbManager.TXCache[pair.Key.K], "Entry %d missing", i)
-			require.Equal(t, pair.Value[:], dbManager.TXCache[pair.Key.K], "Entry %d has wrong value", i)
+			require.NotNil(t, dbManager.txCache[pair.Key.K], "Entry %d missing", i)
+			require.Equal(t, pair.Value[:], dbManager.txCache[pair.Key.K], "Entry %d has wrong value", i)
 		}
 	}
 
@@ -90,7 +89,7 @@ func writeAndReadBatch(t *testing.T, dbManager *database.Manager) {
 
 }
 
-func writeAndRead(t *testing.T, dbManager *database.Manager) {
+func writeAndRead(t *testing.T, dbManager *Manager) {
 	d1 := []byte{1, 2, 3}
 	d2 := []byte{2, 3, 4}
 	d3 := []byte{3, 4, 5}

--- a/smt/storage/keys.go
+++ b/smt/storage/keys.go
@@ -38,7 +38,7 @@ func ComputeKey(keys ...interface{}) Key {
 			bkeys[i] = []byte{}
 		case []byte:
 			bkeys[i] = key
-		case [32]uint8:
+		case [32]byte:
 			bkeys[i] = key[:]
 		case types.Bytes:
 			bkeys[i] = key
@@ -48,6 +48,8 @@ func ComputeKey(keys ...interface{}) Key {
 			bkeys[i] = []byte(key)
 		case types.String:
 			bkeys[i] = []byte(key)
+		case interface{ Bytes() []byte }:
+			bkeys[i] = key.Bytes()
 		case uint:
 			bkeys[i] = common.Uint64Bytes(uint64(key))
 		case uint8:


### PR DESCRIPTION
Allow merkle trees to contain data that is not 32-bytes wide.

No functional changes. Verify that nothing breaks.