### PR TITLE
fix(api/v2): unmarshal acme faucet TXs

### DIFF
--- a/internal/api/v2/unmarshal.go
+++ b/internal/api/v2/unmarshal.go
@@ -83,6 +83,8 @@ func unmarshalTxPayload(b []byte) (protocol.TransactionPayload, error) {
 		payload = new(protocol.SyntheticDepositCredits)
 	case types.TxTypeSyntheticGenesis:
 		payload = new(protocol.SyntheticGenesis)
+	case types.TxTypeAcmeFaucet:
+		payload = new(protocol.AcmeFaucet)
 	default:
 		return nil, fmt.Errorf("unknown TX type %v", typ)
 	}


### PR DESCRIPTION
Fix API v2 so it can unmarshal acme faucet transactions.

Verify with:
```
curl -X POST --data '{ "jsonrpc": "2.0", "id": 0, "method": "faucet", "params": { "url": "'${YOUR_LITE_ACCOUNT}'" } }' -H 'content-type:application/json;' http://127.0.1.1:26660/v2
curl -X POST --data '{ "jsonrpc": "2.0", "id": 4, "method": "query-tx-history", "params": { "url": "acc://7117c50f04f1254d56b704dc05298912deeb25dbc1d26ef6/ACME", "count": 20 } }' -H 'content-type:application/json;' http://127.0.1.1:26660/v2
```