### PR TITLE
fix: cleanup tendermint databases

### DIFF
--- a/internal/testing/node.go
+++ b/internal/testing/node.go
@@ -122,6 +122,10 @@ func NewBVCNode(dir string, memDB bool, relayTo []string, newZL func(string) zer
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create node: %v", err)
 	}
+	go func() {
+		<-node.Quit()
+		sdb.GetDB().Close()
+	}()
 	cleanup(func() {
 		_ = node.Stop()
 		node.Wait()


### PR DESCRIPTION
The [`actually-close-databases` branch of our Tendermint fork](https://github.com/AccumulateNetwork/tendermint/tree/actually-close-databases) fixes issues with Tendermint not cleaning up after itself. Accumulate is already using a more recent version from the fork (branch `fix-rpc-event-sub-again`), so no go.mod changes are necessary.

I updated one of the tests to verify that no files remain open once the node is closed. This uses `/proc/<pid>/fd`, so it's a Linux-only thing.