### PR TITLE
Directory node stub

### DIFF
--- a/cmd/accumulated/cmd_init.go
+++ b/cmd/accumulated/cmd_init.go
@@ -6,13 +6,14 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/AccumulateNetwork/accumulate/config"
 	cfg "github.com/AccumulateNetwork/accumulate/config"
 	"github.com/AccumulateNetwork/accumulate/internal/node"
-	"github.com/AccumulateNetwork/accumulate/internal/relay"
 	"github.com/AccumulateNetwork/accumulate/networks"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -44,7 +45,6 @@ var cmdInitDevnet = &cobra.Command{
 
 var flagInit struct {
 	Net           string
-	Relay         []string
 	NoEmptyBlocks bool
 }
 
@@ -55,6 +55,7 @@ var flagInitFollower struct {
 
 var flagInitDevnet struct {
 	Name          string
+	NumDirNodes   int
 	NumValidators int
 	NumFollowers  int
 	BasePort      int
@@ -66,10 +67,8 @@ func init() {
 	cmdInit.AddCommand(cmdInitFollower, cmdInitDevnet)
 
 	cmdInit.PersistentFlags().StringVarP(&flagInit.Net, "network", "n", "", "Node to build configs for")
-	cmdInit.PersistentFlags().StringSliceVarP(&flagInit.Relay, "relay-to", "r", nil, "Other networks that should be relayed to")
 	cmdInit.PersistentFlags().BoolVar(&flagInit.NoEmptyBlocks, "no-empty-blocks", false, "Do not create empty blocks")
 	cmdInit.MarkFlagRequired("network")
-	cmdInit.MarkFlagRequired("relay-to")
 
 	cmdInitFollower.Flags().StringVar(&flagInitFollower.GenesisDoc, "genesis-doc", "", "Genesis doc for the target network")
 	cmdInitFollower.Flags().StringVarP(&flagInitFollower.ListenIP, "listen", "l", "", "Address and port to listen on, e.g. tcp://1.2.3.4:5678")
@@ -77,58 +76,68 @@ func init() {
 	cmdInitFollower.MarkFlagRequired("listen")
 
 	cmdInitDevnet.Flags().StringVar(&flagInitDevnet.Name, "name", "DevNet", "Network name")
+	cmdInitDevnet.Flags().IntVarP(&flagInitDevnet.NumDirNodes, "directory-nodes", "d", 1, "Number of directory validator nodes to configure")
 	cmdInitDevnet.Flags().IntVarP(&flagInitDevnet.NumValidators, "validators", "v", 2, "Number of validator nodes to configure")
 	cmdInitDevnet.Flags().IntVarP(&flagInitDevnet.NumFollowers, "followers", "f", 1, "Number of follower nodes to configure")
 	cmdInitDevnet.Flags().IntVar(&flagInitDevnet.BasePort, "port", 26656, "Base port to use for listeners")
 	cmdInitDevnet.Flags().StringVar(&flagInitDevnet.BaseIP, "ip", "127.0.1.1", "Base IP address for nodes - must not end with .0")
 }
 
-func initNode(cmd *cobra.Command, args []string) {
-	network := networks.All[flagInit.Net]
-	if network == nil {
-		fatalf("unknown network %q", flagInit.Net)
-	}
+func initNode(*cobra.Command, []string) {
+	subnet, err := networks.Resolve(flagInit.Net)
+	checkf(err, "--network")
 
-	if !stringSliceContains(flagInit.Relay, flagInit.Net) {
-		fmt.Fprintf(os.Stderr, "Error: the node's own network, %q, must be included in --relay-to\n", flagInit.Net)
-		printUsageAndExit1(cmd, args)
-	}
+	// Build the relay list
+	var relayTo []string
+	switch subnet.Type {
+	case cfg.Directory:
+		relayTo = []string{subnet.FullName()}
 
-	_, err := relay.NewWith(flagInit.Relay...)
-	checkf(err, "--relay-to", err)
+	case cfg.BlockValidator:
+		index := map[string]int{}
+		for _, s := range subnet.Network {
+			if s.Type != cfg.BlockValidator {
+				continue
+			}
 
-	fmt.Printf("Building config for %s\n", network.Name)
+			name := s.FullName()
+			if s == subnet {
+				name = "self"
+			}
 
-	listenIP := make([]string, len(network.Nodes))
-	remoteIP := make([]string, len(network.Nodes))
-	config := make([]*cfg.Config, len(network.Nodes))
-
-	for i, net := range network.Nodes {
-		listenIP[i] = "tcp://0.0.0.0"
-		remoteIP[i] = net.IP
-
-		switch net.Type {
-		case cfg.Validator:
-			config[i] = cfg.DefaultValidator()
-		case cfg.Follower:
-			config[i] = cfg.Default()
-		default:
-			fatalf("hard-coded network has invalid node type: %q", net.Type)
+			relayTo = append(relayTo, name)
+			index[name] = s.Index
 		}
+		sort.Slice(relayTo, func(i, j int) bool {
+			return index[relayTo[i]] < index[relayTo[j]]
+		})
+	}
+
+	fmt.Printf("Building config for %s (%s)\n", subnet.Name, subnet.NetworkName)
+
+	listenIP := make([]string, len(subnet.Nodes))
+	remoteIP := make([]string, len(subnet.Nodes))
+	config := make([]*cfg.Config, len(subnet.Nodes))
+
+	for i, node := range subnet.Nodes {
+		listenIP[i] = "tcp://0.0.0.0"
+		remoteIP[i] = node.IP
+		config[i] = cfg.Default(subnet.Type, node.Type)
 
 		if flagInit.NoEmptyBlocks {
 			config[i].Consensus.CreateEmptyBlocks = false
 		}
 
-		config[i].Accumulate.Type = network.Type
-		config[i].Accumulate.Networks = flagInit.Relay
+		config[i].Accumulate.Network = subnet.FullName()
+		config[i].Accumulate.Networks = relayTo
+		config[i].Accumulate.Directory = subnet.Directory
 	}
 
 	check(node.Init(node.InitOptions{
 		WorkDir:   flagMain.WorkDir,
 		ShardName: "accumulate.",
-		ChainID:   network.Name,
-		Port:      network.Port,
+		ChainID:   subnet.Name,
+		Port:      subnet.Port,
 		Config:    config,
 		RemoteIP:  remoteIP,
 		ListenIP:  listenIP,
@@ -149,10 +158,8 @@ func initFollower(cmd *cobra.Command, _ []string) {
 		u.Host = u.Host[:len(u.Host)-len(u.Port())-1]
 	}
 
-	network := networks.All[flagInit.Net]
-	if network == nil {
-		fatalf("unknown network %q", flagInit.Net)
-	}
+	subnet, err := networks.Resolve(flagInit.Net)
+	checkf(err, "--network")
 
 	var genDoc *types.GenesisDoc
 	if cmd.Flag("genesis-doc").Changed {
@@ -160,9 +167,9 @@ func initFollower(cmd *cobra.Command, _ []string) {
 		checkf(err, "failed to load genesis doc %q", flagInitFollower.GenesisDoc)
 	}
 
-	peers := make([]string, len(network.Nodes))
-	for i, n := range network.Nodes {
-		client, err := rpchttp.New(fmt.Sprintf("tcp://%s:%d", n.IP, network.Port+node.TmRpcPortOffset))
+	peers := make([]string, len(subnet.Nodes))
+	for i, n := range subnet.Nodes {
+		client, err := rpchttp.New(fmt.Sprintf("tcp://%s:%d", n.IP, subnet.Port+node.TmRpcPortOffset))
 		checkf(err, "failed to connect to %s", n.IP)
 
 		if genDoc == nil {
@@ -180,16 +187,16 @@ func initFollower(cmd *cobra.Command, _ []string) {
 		status, err := client.Status(context.Background())
 		checkf(err, "failed to get status of %s", n)
 
-		peers[i] = fmt.Sprintf("%s@%s:%d", status.NodeInfo.NodeID, n.IP, network.Port)
+		peers[i] = fmt.Sprintf("%s@%s:%d", status.NodeInfo.NodeID, n.IP, subnet.Port)
 	}
 
-	config := config.Default()
+	config := config.Default(subnet.Type, cfg.Follower)
 	config.P2P.PersistentPeers = strings.Join(peers, ",")
 
 	check(node.Init(node.InitOptions{
 		WorkDir:    flagMain.WorkDir,
 		ShardName:  "accumulate.",
-		ChainID:    network.Name,
+		ChainID:    subnet.Name,
 		Port:       port,
 		GenesisDoc: genDoc,
 		Config:     []*cfg.Config{config},
@@ -198,12 +205,24 @@ func initFollower(cmd *cobra.Command, _ []string) {
 	}))
 }
 
+func nextIP(baseIP net.IP) net.IP {
+	ip := make(net.IP, len(baseIP))
+	copy(ip, baseIP)
+	baseIP[15]++
+	return ip
+}
+
 func initDevNet(cmd *cobra.Command, args []string) {
 	if cmd.Flag("network").Changed {
 		fatalf("--network is not applicable to devnet")
 	}
-	if cmd.Flag("relay-to").Changed {
-		fatalf("--relay-to is not applicable to devnet")
+
+	if flagInitDevnet.NumDirNodes == 0 {
+		fatalf("Must have at least one directory node")
+	}
+
+	if flagInitDevnet.NumValidators == 0 {
+		fatalf("Must have at least one block validator node")
 	}
 
 	baseIP := net.ParseIP(flagInitDevnet.BaseIP)
@@ -216,35 +235,53 @@ func initDevNet(cmd *cobra.Command, args []string) {
 		printUsageAndExit1(cmd, args)
 	}
 
-	count := flagInitDevnet.NumValidators + flagInitDevnet.NumFollowers
-	IPs := make([]string, count)
-	config := make([]*cfg.Config, count)
+	IPs := make([]string, flagInitDevnet.NumDirNodes+flagInitDevnet.NumValidators+flagInitDevnet.NumFollowers)
 	for i := range IPs {
-		ip := make(net.IP, len(baseIP))
-		copy(ip, baseIP)
-		ip[15] += byte(i)
+		ip := nextIP(baseIP)
 		IPs[i] = fmt.Sprintf("tcp://%v", ip)
 	}
 
-	for i := range config {
-		if i < flagInitDevnet.NumValidators {
-			config[i] = cfg.DefaultValidator()
+	config := make([]*cfg.Config, 0, len(IPs))
+	for i := 0; i < flagInitDevnet.NumDirNodes; i++ {
+		config = append(config, cfg.Default(cfg.Directory, cfg.Validator))
+	}
+	for i := 0; i < flagInitDevnet.NumValidators; i++ {
+		config = append(config, cfg.Default(cfg.BlockValidator, cfg.Validator))
+	}
+	for i := 0; i < flagInitDevnet.NumFollowers; i++ {
+		config = append(config, cfg.Default(cfg.BlockValidator, cfg.Follower))
+	}
+
+	for _, config := range config {
+		ip := IPs[flagInitDevnet.NumDirNodes]
+		if config.Accumulate.Type == cfg.Directory {
+			ip = IPs[0]
 		} else {
-			config[i] = cfg.Default()
+			config.Accumulate.Directory = IPs[0]
 		}
-		config[i].Accumulate.Networks = []string{fmt.Sprintf("%s:%d", IPs[0], flagInitDevnet.BasePort+node.TmRpcPortOffset)}
+		config.Accumulate.Network = "LocalDevNet"
+		config.Accumulate.Networks = []string{fmt.Sprintf("%s:%d", ip, flagInitDevnet.BasePort+node.TmRpcPortOffset)}
 		if flagInit.NoEmptyBlocks {
-			config[i].Consensus.CreateEmptyBlocks = false
+			config.Consensus.CreateEmptyBlocks = false
 		}
 	}
 
 	check(node.Init(node.InitOptions{
-		WorkDir:   flagMain.WorkDir,
+		WorkDir:   filepath.Join(flagMain.WorkDir, "dn"),
 		ShardName: flagInitDevnet.Name,
 		ChainID:   flagInitDevnet.Name,
 		Port:      flagInitDevnet.BasePort,
-		Config:    config,
-		RemoteIP:  IPs,
-		ListenIP:  IPs,
+		Config:    config[:flagInitDevnet.NumDirNodes],
+		RemoteIP:  IPs[:flagInitDevnet.NumDirNodes],
+		ListenIP:  IPs[:flagInitDevnet.NumDirNodes],
+	}))
+	check(node.Init(node.InitOptions{
+		WorkDir:   filepath.Join(flagMain.WorkDir, "bvn"),
+		ShardName: flagInitDevnet.Name,
+		ChainID:   flagInitDevnet.Name,
+		Port:      flagInitDevnet.BasePort,
+		Config:    config[flagInitDevnet.NumDirNodes:],
+		RemoteIP:  IPs[flagInitDevnet.NumDirNodes:],
+		ListenIP:  IPs[flagInitDevnet.NumDirNodes:],
 	}))
 }

--- a/cmd/accumulated/cmd_loadtest.go
+++ b/cmd/accumulated/cmd_loadtest.go
@@ -68,10 +68,8 @@ func loadTest(cmd *cobra.Command, args []string) {
 
 	// Create clients for networks
 	for _, name := range flagLoadTest.Networks {
-		net := networks.All[name]
-		if net == nil {
-			fatalf("unknown network %q", flagInit.Net)
-		}
+		net, err := networks.Resolve(flagInit.Net)
+		checkf(err, "--network")
 
 		lAddr := fmt.Sprintf("tcp://%s:%d", net.Nodes[0].IP, net.Port+node.TmRpcPortOffset)
 		client, err := rpc.New(lAddr)

--- a/config/config.go
+++ b/config/config.go
@@ -14,8 +14,8 @@ import (
 type NetworkType string
 
 const (
-	BVC NetworkType = "bvc"
-	DC  NetworkType = "dc"
+	BlockValidator NetworkType = "block-validator"
+	Directory      NetworkType = "directory"
 )
 
 type NodeType string
@@ -25,17 +25,16 @@ const (
 	Follower  NodeType = "follower"
 )
 
-func Default() *Config {
+func Default(net NetworkType, node NodeType) *Config {
 	c := new(Config)
+	c.Accumulate.Type = net
 	c.Accumulate.API.PrometheusServer = "http://18.119.26.7:9090"
-	c.Config = *tm.DefaultConfig()
-	return c
-}
-
-func DefaultValidator() *Config {
-	c := new(Config)
-	c.Accumulate.API.PrometheusServer = "http://18.119.26.7:9090"
-	c.Config = *tm.DefaultValidatorConfig()
+	switch node {
+	case Validator:
+		c.Config = *tm.DefaultValidatorConfig()
+	default:
+		c.Config = *tm.DefaultConfig()
+	}
 	return c
 }
 
@@ -45,10 +44,11 @@ type Config struct {
 }
 
 type Accumulate struct {
-	Type     NetworkType `toml:"type" mapstructure:"type"`
-	Network  string      `toml:"network" mapstructure:"network"`
-	Networks []string    `toml:"networks" mapstructure:"networks"`
-	API      API         `toml:"api" mapstructure:"api"`
+	Type      NetworkType `toml:"type" mapstructure:"type"`
+	Network   string      `toml:"network" mapstructure:"network"`
+	Networks  []string    `toml:"networks" mapstructure:"networks"`
+	API       API         `toml:"api" mapstructure:"api"`
+	Directory string      `toml:"directory" mapstructure:"directory"`
 
 	WebsiteEnabled       bool   `toml:"website-enabled" mapstructure:"website-enabled"`
 	WebsiteListenAddress string `toml:"website-listen-address" mapstructure:"website-listen-address"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,9 +13,8 @@ func TestPersistence(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "config"), 0777))
 
 	// Create
-	cfg := DefaultValidator()
+	cfg := Default(BlockValidator, Follower)
 	cfg.SetRoot(dir)
-	cfg.Accumulate.Type = BVC
 	cfg.Accumulate.API.JSONListenAddress = "api-json-listen"
 	cfg.Accumulate.API.RESTListenAddress = "api-rest-listen"
 

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -91,7 +91,7 @@ func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel st
 	t.Cleanup(func() { require.NoError(t, relay.Stop()) })
 	n.query = accapi.NewQuery(relay)
 
-	mgr, err := chain.NewBlockValidator(n.query, db, bvcKey)
+	mgr, err := chain.NewBlockValidatorExecutor(n.query, db, bvcKey)
 	require.NoError(t, err)
 
 	n.app, err = abci.NewAccumulator(db, addr, mgr, logger)

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/AccumulateNetwork/accumulate/internal/node"
 	"github.com/AccumulateNetwork/accumulate/internal/relay"
 	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
-	"github.com/AccumulateNetwork/accumulate/networks"
 	"github.com/AccumulateNetwork/accumulate/types/state"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -22,7 +21,7 @@ import (
 func startBVC(t *testing.T, dir string) (*state.StateDB, *privval.FilePV, *Query) {
 	t.Helper()
 
-	opts, err := acctesting.NodeInitOptsForNetwork(networks.Local["Badlands"])
+	opts, err := acctesting.NodeInitOptsForNetwork(acctesting.LocalBVN)
 	require.NoError(t, err)
 	opts.WorkDir = dir
 	opts.Port = GetFreePort(t)

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -11,7 +11,7 @@ import (
 	"github.com/AccumulateNetwork/accumulate/types/state"
 )
 
-func NewBlockValidator(query *accapi.Query, db *state.StateDB, key ed25519.PrivateKey) (*Executor, error) {
+func NewBlockValidatorExecutor(query *accapi.Query, db *state.StateDB, key ed25519.PrivateKey) (*Executor, error) {
 	return NewExecutor(query, db, key,
 		CreateIdentity{},
 		WithdrawTokens{},
@@ -28,6 +28,11 @@ func NewBlockValidator(query *accapi.Query, db *state.StateDB, key ed25519.Priva
 		// TODO Only for TestNet
 		AcmeFaucet{},
 	)
+}
+
+func NewDirectoryExecutor(query *accapi.Query, db *state.StateDB, key ed25519.PrivateKey) (*Executor, error) {
+	return NewExecutor(query, db, key) // TODO Add DN validators
+
 }
 
 // TxExecutor executes a specific type of transaction.

--- a/internal/node/init.go
+++ b/internal/node/init.go
@@ -63,7 +63,6 @@ func Init(opts InitOptions) (err error) {
 		config.RPC.GRPCListenAddress = fmt.Sprintf("%s:%d", opts.ListenIP[i], opts.Port+tmRpcGrpcPortOffset)
 		config.Instrumentation.PrometheusListenAddr = fmt.Sprintf(":%d", opts.Port+tmPrometheusPortOffset)
 		config.Instrumentation.Prometheus = true
-		config.Accumulate.Network = opts.ChainID
 
 		err = os.MkdirAll(path.Join(nodeDir, "config"), nodeDirPerm)
 		if err != nil {

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/AccumulateNetwork/accumulate/internal/logging"
 	"github.com/AccumulateNetwork/accumulate/internal/node"
 	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
-	"github.com/AccumulateNetwork/accumulate/networks"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +27,7 @@ func TestNodeLifecycle(t *testing.T) {
 		t.Skip("Skipping test in short mode")
 	}
 
-	opts, err := acctesting.NodeInitOptsForNetwork(networks.Local["Badlands"])
+	opts, err := acctesting.NodeInitOptsForNetwork(acctesting.LocalBVN)
 	require.NoError(t, err)
 	opts.WorkDir = t.TempDir()
 	opts.Port = getFreePort(t)
@@ -92,7 +91,7 @@ func TestNodeSetupTwiceWithPrometheus(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		t.Run(fmt.Sprintf("Try %d", i+1), func(t *testing.T) {
-			opts, err := acctesting.NodeInitOptsForNetwork(networks.Local["Badlands"])
+			opts, err := acctesting.NodeInitOptsForNetwork(acctesting.LocalBVN)
 			require.NoError(t, err)
 			opts.ShardName = "accumulate"
 			opts.WorkDir = t.TempDir()

--- a/internal/node/utils_test.go
+++ b/internal/node/utils_test.go
@@ -33,7 +33,7 @@ func initNodes(t *testing.T, name string, baseIP net.IP, basePort int, count int
 	}
 
 	for i := range config {
-		config[i] = cfg.DefaultValidator()
+		config[i] = cfg.Default(cfg.BlockValidator, cfg.Validator)
 		if relay != nil {
 			config[i].Accumulate.Networks = make([]string, len(relay))
 			for j, r := range relay {

--- a/internal/testing/node.go
+++ b/internal/testing/node.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/AccumulateNetwork/accumulate/config"
 	cfg "github.com/AccumulateNetwork/accumulate/config"
 	"github.com/AccumulateNetwork/accumulate/internal/abci"
 	"github.com/AccumulateNetwork/accumulate/internal/api"
@@ -18,6 +19,15 @@ import (
 	tmcfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/privval"
 )
+
+var LocalBVN = &networks.Subnet{
+	Name: "Local",
+	Type: config.BlockValidator,
+	Port: 35550,
+	Nodes: []networks.Node{
+		{IP: "127.0.0.1", Type: config.Validator},
+	},
+}
 
 func NodeInitOptsForNetwork(network *networks.Subnet) (node.InitOptions, error) {
 	listenIP := make([]string, len(network.Nodes))
@@ -89,7 +99,7 @@ func NewBVCNode(dir string, memDB bool, relayTo []string, newZL func(string) zer
 		return nil, nil, nil, fmt.Errorf("failed to create RPC relay: %v", err)
 	}
 
-	mgr, err := chain.NewBlockValidator(api.NewQuery(relay), sdb, pv.Key.PrivKey.Bytes())
+	mgr, err := chain.NewBlockValidatorExecutor(api.NewQuery(relay), sdb, pv.Key.PrivKey.Bytes())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create chain manager: %v", err)
 	}

--- a/networks/get.go
+++ b/networks/get.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetRpcAddr(netOrIp string, portOffset int) (string, error) {
-	net := All[netOrIp]
+	net := all[netOrIp]
 	ip, err := url.Parse(netOrIp)
 	if net != nil {
 		ip = &url.URL{Scheme: "tcp", Host: fmt.Sprintf("%s:%d", net.Nodes[0].IP, net.Port+portOffset)}
@@ -20,4 +20,15 @@ func GetRpcAddr(netOrIp string, portOffset int) (string, error) {
 	}
 
 	return ip.String(), nil
+}
+
+func Resolve(name string) (*Subnet, error) {
+	sub := all[name]
+	if sub != nil {
+		return sub, nil
+	}
+	if nameCount[name] > 1 {
+		return nil, fmt.Errorf("%q is ambiguous and must be qualified with the network name", name)
+	}
+	return nil, fmt.Errorf("%q is not the name of a subnet", name)
 }


### PR DESCRIPTION
Implements a directory node stub, plus corresponding configuration and initialization changes.

To verify:
- `accumulated init -n DevNet.Zion` - works as usual, `accumulate.toml` specifies `directory = "DevNet.Directory"`
- `accumulated init -n DevNet.Directory` - four nodes, two validators and two followers, `accumulate.toml` specifies `type = "directory"`
- `accumulated init devnet` - creates a local devnet with a DN and one BVN