### PR TITLE
pass the count through

### DIFF
--- a/internal/api/v2/query_direct.go
+++ b/internal/api/v2/query_direct.go
@@ -219,7 +219,7 @@ func (q queryDirect) QueryTxHistory(s string, start, count int64) (*QueryMultiRe
 	res := new(QueryMultiResponse)
 	res.Items = make([]*QueryResponse, len(txh.Transactions))
 	res.Start = uint64(start)
-	res.Count = uint64(len(txh.Transactions))
+	res.Count = uint64(count)
 	res.Total = uint64(txh.Total)
 	for i, tx := range txh.Transactions {
 		main, pend, pl, err := unmarshalTxResponse(tx.TxState, tx.TxPendingState)


### PR DESCRIPTION
The explorer wants `count` to be passed through from the request to the response, unchanged.