### PR TITLE
Add basic genesis app state to genesis doc

### DIFF
--- a/cmd/accumulated/cmd_init.go
+++ b/cmd/accumulated/cmd_init.go
@@ -134,7 +134,7 @@ func initNode(*cobra.Command, []string) {
 	check(node.Init(node.InitOptions{
 		WorkDir:   flagMain.WorkDir,
 		ShardName: "accumulate.",
-		ChainID:   subnet.Name,
+		SubnetID:  subnet.Name,
 		Port:      subnet.Port,
 		Config:    config,
 		RemoteIP:  remoteIP,
@@ -194,7 +194,7 @@ func initFollower(cmd *cobra.Command, _ []string) {
 	check(node.Init(node.InitOptions{
 		WorkDir:    flagMain.WorkDir,
 		ShardName:  "accumulate.",
-		ChainID:    subnet.Name,
+		SubnetID:   subnet.Name,
 		Port:       port,
 		GenesisDoc: genDoc,
 		Config:     []*cfg.Config{config},
@@ -268,7 +268,7 @@ func initDevNet(cmd *cobra.Command, args []string) {
 	check(node.Init(node.InitOptions{
 		WorkDir:   filepath.Join(flagMain.WorkDir, "dn"),
 		ShardName: flagInitDevnet.Name,
-		ChainID:   flagInitDevnet.Name,
+		SubnetID:  flagInitDevnet.Name,
 		Port:      flagInitDevnet.BasePort,
 		Config:    config[:flagInitDevnet.NumDirNodes],
 		RemoteIP:  IPs[:flagInitDevnet.NumDirNodes],
@@ -277,7 +277,7 @@ func initDevNet(cmd *cobra.Command, args []string) {
 	check(node.Init(node.InitOptions{
 		WorkDir:   filepath.Join(flagMain.WorkDir, "bvn"),
 		ShardName: flagInitDevnet.Name,
-		ChainID:   flagInitDevnet.Name,
+		SubnetID:  flagInitDevnet.Name,
 		Port:      flagInitDevnet.BasePort,
 		Config:    config[flagInitDevnet.NumDirNodes:],
 		RemoteIP:  IPs[flagInitDevnet.NumDirNodes:],

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -35,6 +35,8 @@ type EndBlockRequest struct{}
 type Chain interface {
 	Query(*apiQuery.Query) (k, v []byte, err *protocol.Error)
 
+	InitChain(state []byte) error
+
 	BeginBlock(BeginBlockRequest)
 	CheckTx(*transactions.GenTransaction) *protocol.Error
 	DeliverTx(*transactions.GenTransaction) (*protocol.TxResult, *protocol.Error)
@@ -43,6 +45,9 @@ type Chain interface {
 }
 
 type State interface {
+	// SubnetID returns the ID of the subnet
+	SubnetID() (string, error)
+
 	// BlockIndex returns the current block index/height of the chain
 	BlockIndex() (int64, error)
 

--- a/internal/abci/accumulator_test.go
+++ b/internal/abci/accumulator_test.go
@@ -179,6 +179,8 @@ func (s *AccumulatorTestSuite) vars() *accVars {
 	v.Chain = mock_abci.NewMockChain(v.MockCtrl)
 	s.varMap[s.T()] = v
 
+	v.State.EXPECT().SubnetID().AnyTimes()
+
 	s.T().Cleanup(func() {
 		v.MockCtrl.Finish()
 	})

--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -35,8 +35,9 @@ func TestEndToEndSuite(t *testing.T) {
 		// Recreate the app for each test
 		n := createAppWithMemDB(s.T(), crypto.Address{}, "error", false)
 		n.app.InitChain(abci.RequestInitChain{
-			Time:    time.Now(),
-			ChainId: s.T().Name(),
+			Time:          time.Now(),
+			ChainId:       s.T().Name(),
+			AppStateBytes: []byte(`""`),
 		})
 		return n.query
 	}))

--- a/internal/mock/abci/abci.go
+++ b/internal/mock/abci/abci.go
@@ -105,6 +105,20 @@ func (mr *MockChainMockRecorder) EndBlock(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndBlock", reflect.TypeOf((*MockChain)(nil).EndBlock), arg0)
 }
 
+// InitChain mocks base method.
+func (m *MockChain) InitChain(state []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitChain", state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InitChain indicates an expected call of InitChain.
+func (mr *MockChainMockRecorder) InitChain(state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitChain", reflect.TypeOf((*MockChain)(nil).InitChain), state)
+}
+
 // Query mocks base method.
 func (m *MockChain) Query(arg0 *query.Query) ([]byte, []byte, *protocol.Error) {
 	m.ctrl.T.Helper()
@@ -171,4 +185,19 @@ func (m *MockState) RootHash() []byte {
 func (mr *MockStateMockRecorder) RootHash() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHash", reflect.TypeOf((*MockState)(nil).RootHash))
+}
+
+// SubnetID mocks base method.
+func (m *MockState) SubnetID() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubnetID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubnetID indicates an expected call of SubnetID.
+func (mr *MockStateMockRecorder) SubnetID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetID", reflect.TypeOf((*MockState)(nil).SubnetID))
 }

--- a/internal/node/init.go
+++ b/internal/node/init.go
@@ -2,11 +2,14 @@ package node
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 
 	cfg "github.com/AccumulateNetwork/accumulate/config"
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
+	"github.com/AccumulateNetwork/accumulate/smt/storage/memory"
 	tmcfg "github.com/tendermint/tendermint/config"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmos "github.com/tendermint/tendermint/libs/os"
@@ -29,7 +32,7 @@ const (
 type InitOptions struct {
 	WorkDir    string
 	ShardName  string
-	ChainID    string
+	SubnetID   string
 	Port       int
 	GenesisDoc *types.GenesisDoc
 	Config     []*cfg.Config
@@ -74,7 +77,7 @@ func Init(opts InitOptions) (err error) {
 			return fmt.Errorf("failed to create data dir: %v", err)
 		}
 
-		if err := initFilesWithConfig(config, &opts.ChainID); err != nil {
+		if err := initFilesWithConfig(config, &opts.SubnetID); err != nil {
 			return err
 		}
 
@@ -103,12 +106,24 @@ func Init(opts InitOptions) (err error) {
 	// Generate genesis doc from generated validators
 	genDoc := opts.GenesisDoc
 	if genDoc == nil {
+		db := new(memory.DB)
+		_ = db.InitDB("")
+		_ = db.Put(storage.ComputeKey("SubnetID"), []byte(opts.SubnetID))
+		state, _ := db.MarshalBinary()
+		state, err := json.Marshal(state)
+		if err != nil {
+			return err
+		}
+		bptRoot := make([]byte, 32)
+
 		genDoc = &types.GenesisDoc{
-			ChainID:         opts.ChainID,
+			ChainID:         opts.SubnetID,
 			GenesisTime:     tmtime.Now(),
 			InitialHeight:   0,
 			Validators:      genVals,
 			ConsensusParams: types.DefaultConsensusParams(),
+			AppState:        state,
+			AppHash:         bptRoot,
 		}
 	}
 

--- a/internal/node/utils_test.go
+++ b/internal/node/utils_test.go
@@ -50,7 +50,7 @@ func initNodes(t *testing.T, name string, baseIP net.IP, basePort int, count int
 	require.NoError(t, node.Init(node.InitOptions{
 		WorkDir:   workDir,
 		ShardName: name,
-		ChainID:   name,
+		SubnetID:  name,
 		Port:      basePort,
 		Config:    config,
 		RemoteIP:  IPs,

--- a/internal/testing/node.go
+++ b/internal/testing/node.go
@@ -56,7 +56,7 @@ func NodeInitOptsForNetwork(network *networks.Subnet) (node.InitOptions, error) 
 
 	return node.InitOptions{
 		ShardName: "accumulate.",
-		ChainID:   network.Name,
+		SubnetID:  network.Name,
 		Port:      network.Port,
 		Config:    config,
 		RemoteIP:  remoteIP,

--- a/types/state/StateDB.go
+++ b/types/state/StateDB.go
@@ -560,6 +560,15 @@ func (s *StateDB) getAnchorHead() (*AnchorMetadata, error) {
 
 	return head, nil
 }
+
+func (s *StateDB) SubnetID() (string, error) {
+	b, err := s.GetDB().Key("SubnetID").Get()
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 func (s *StateDB) BlockIndex() (int64, error) {
 	head, err := s.getAnchorHead()
 	if err != nil {


### PR DESCRIPTION
Updates node setup and ABCI chain initialization to preload the database. Node setup initializes a `memory.DB` and marshals it, saving it as the app state in the genesis document. ABCI chain initialization loads the app state (from the genesis doc) and pushes it into the database.

This will allow us to add arbitrary state to the node database during setup by directly manipulating the `memory.DB` and executing transactions. Right now, all it does is set "ChainID".

To verify, setup and launch a node, then stop it, then restart it. Verify that one of the startup messages is `Starting ABCI ... chain=<chainId> module=accumulate`. Previously, `chain=...` only appeared the first time the node was launched, as the chain ID was set by InitChain, which is only called the first time the node launches.