### PR TITLE
ci: deploy DN to DevNet

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,15 +77,14 @@ configure:
   script:
   - |
     function init {
-      rm -rf .nodes
-      ./accumulated init -w .nodes --no-empty-blocks -n $1
-      tar czf config-$1.tar.gz -C .nodes .
+      ./accumulated init -w config-$1 "${@:2}" -n $1
+      (cd config-$1 && tar czf ../config-$1.tar.gz *)
     }
   - build-daemon
-  - build-daemon linux amd64
   - build-daemon linux arm64
-  - init Zion
-  - init Yellowstone
+  - init DevNet.Directory --no-empty-blocks --no-website
+  - init DevNet.Zion --no-empty-blocks
+  - init DevNet.Yellowstone --no-empty-blocks
   artifacts:
     paths:
     - config-*.tar.gz
@@ -107,44 +106,26 @@ configure:
   - cp ${SSH_PRIV_KEY} ~/.ssh/id_rsa
   - cp ${SSH_PUB_KEY} ~/.ssh/id_rsa.pub
   - chmod -R 600 ~/.ssh
-  - scp ${BIN} ec2-user@${HOST}:accumulated-latest
-  - scp config-${NETWORK}.tar.gz ec2-user@${HOST}:config.tar.gz
-  - ssh ec2-user@${HOST} '~/accumulated-latest version'
-  - varname=DEPLOY_${NETWORK}_${NODE}
-  - echo ${varname}=${!varname}
-  - |
-    if [ "${!varname}" = "yes" ]; then ssh ec2-user@${HOST} "
-      set -ex
-      export PATH="'"$PATH:$HOME/.local/bin"'"
-      screen -wipe || true
-      screen -ls | grep '\baccumulated\b' && screen -S accumulated -X stuff ^C
-      while screen -ls | grep -q '\baccumulated\b'; do sleep 1; done
-      rm -f ~/.local/bin/accumulated
-      mv accumulated-latest ~/.local/bin/accumulated
-      rm -rf ~/.accumulate
-      mkdir ~/.accumulate
-      tar xf config.tar.gz -C ~/.accumulate
-      screen -d -m -S accumulated bash -c 'accumulated run -n ${NODE} 2>&1 | tee ~/.accumulate/Node${NODE}/acc-$(date +%Y%m%d%H%M%S).log'
-    "; fi
+  - ./scripts/ci/devnet-deploy.sh
 
 deploy 1/4:
   extends: .deploy
-  variables:   { HOST: 172.31.4.106,  NETWORK: Zion,         NODE: 0, BIN: accumulated-linux-arm64 }
+  variables:   { HOST: 172.31.4.106,  NETWORK: Zion,         NODE: 0, DN_NODE: 0, BIN: accumulated-linux-arm64 }
   environment: { url: 'http://172.31.4.106:8080',  name: Zion/0 }
 
 deploy 2/4:
   extends: .deploy
-  variables:   { HOST: 172.31.11.185, NETWORK: Zion,         NODE: 1, BIN: accumulated-linux-arm64 }
+  variables:   { HOST: 172.31.11.185, NETWORK: Zion,         NODE: 1, DN_NODE: 1, BIN: accumulated-linux-arm64 }
   environment: { url: 'http://172.31.11.185:8080', name: Zion/1 }
 
 deploy 3/4:
   extends: .deploy
-  variables:   { HOST: 172.31.11.104, NETWORK: Yellowstone,  NODE: 0, BIN: accumulated-linux-arm64 }
+  variables:   { HOST: 172.31.11.104, NETWORK: Yellowstone,  NODE: 0, DN_NODE: 2, BIN: accumulated-linux-arm64 }
   environment: { url: 'http://172.31.11.104:8080', name: Yellowstone/0 }
 
 deploy 4/4:
   extends: .deploy
-  variables:   { HOST: 172.31.13.8,   NETWORK: Yellowstone,  NODE: 1, BIN: accumulated-linux-arm64 }
+  variables:   { HOST: 172.31.13.8,   NETWORK: Yellowstone,  NODE: 1, DN_NODE: 3, BIN: accumulated-linux-arm64 }
   environment: { url: 'http://172.31.13.8:8080',   name: Yellowstone/1 }
 
 validate:

--- a/cmd/accumulated/cmd_init.go
+++ b/cmd/accumulated/cmd_init.go
@@ -46,6 +46,7 @@ var cmdInitDevnet = &cobra.Command{
 var flagInit struct {
 	Net           string
 	NoEmptyBlocks bool
+	NoWebsite     bool
 }
 
 var flagInitFollower struct {
@@ -68,6 +69,7 @@ func init() {
 
 	cmdInit.PersistentFlags().StringVarP(&flagInit.Net, "network", "n", "", "Node to build configs for")
 	cmdInit.PersistentFlags().BoolVar(&flagInit.NoEmptyBlocks, "no-empty-blocks", false, "Do not create empty blocks")
+	cmdInit.PersistentFlags().BoolVar(&flagInit.NoWebsite, "no-website", false, "Disable website")
 	cmdInit.MarkFlagRequired("network")
 
 	cmdInitFollower.Flags().StringVar(&flagInitFollower.GenesisDoc, "genesis-doc", "", "Genesis doc for the target network")
@@ -124,6 +126,10 @@ func initNode(*cobra.Command, []string) {
 
 		if flagInit.NoEmptyBlocks {
 			config[i].Consensus.CreateEmptyBlocks = false
+		}
+
+		if flagInit.NoWebsite {
+			config[i].Accumulate.WebsiteEnabled = false
 		}
 
 		config[i].Accumulate.Network = subnet.FullName()
@@ -262,6 +268,9 @@ func initDevNet(cmd *cobra.Command, args []string) {
 		config.Accumulate.Networks = []string{fmt.Sprintf("%s:%d", ip, flagInitDevnet.BasePort+node.TmRpcPortOffset)}
 		if flagInit.NoEmptyBlocks {
 			config.Consensus.CreateEmptyBlocks = false
+		}
+		if flagInit.NoWebsite {
+			config.Accumulate.WebsiteEnabled = false
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,8 @@ func Default(net NetworkType, node NodeType) *Config {
 	c := new(Config)
 	c.Accumulate.Type = net
 	c.Accumulate.API.PrometheusServer = "http://18.119.26.7:9090"
+	c.Accumulate.SentryDSN = "https://glet_78c3bf45d009794a4d9b0c990a1f1ed5@gitlab.com/api/v4/error_tracking/collector/29762666"
+	c.Accumulate.WebsiteEnabled = true
 	switch node {
 	case Validator:
 		c.Config = *tm.DefaultValidatorConfig()

--- a/internal/node/init.go
+++ b/internal/node/init.go
@@ -169,8 +169,6 @@ func Init(opts InitOptions) (err error) {
 		}
 		config.Moniker = fmt.Sprintf("Node%d", i)
 
-		config.Accumulate.SentryDSN = "https://glet_78c3bf45d009794a4d9b0c990a1f1ed5@gitlab.com/api/v4/error_tracking/collector/29762666"
-		config.Accumulate.WebsiteEnabled = true
 		config.Accumulate.WebsiteListenAddress = fmt.Sprintf("%s:8080", opts.ListenIP[i])
 		config.Accumulate.API.JSONListenAddress = fmt.Sprintf("%s:%d", opts.ListenIP[i], opts.Port+accRouterJsonPortOffset)
 		config.Accumulate.API.RESTListenAddress = fmt.Sprintf("%s:%d", opts.ListenIP[i], opts.Port+accRouterRestPortOffset)

--- a/scripts/ci/devnet-deploy.sh
+++ b/scripts/ci/devnet-deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ -z "${BIN}" ] || [ -z "${HOST}" ] || [ -z "${NETWORK}" ] || [ -z "${NODE}" ] || [ -z "${DN_NODE}" ]; then
+    echo "Environment variables must be specified"
+    echo "  HOST: '${HOST}'"
+    echo "  NETWORK: '${NETWORK}'"
+    echo "  NODE: '${NODE}'"
+    echo "  DN_NODE: '${DN_NODE}'"
+    echo "  BIN: '${BIN}'"
+    exit 1
+fi
+
+# Deploy configuration and the binary
+scp ${BIN} ec2-user@${HOST}:accumulated-latest
+scp config-DevNet.Directory.tar.gz ec2-user@${HOST}:config-dn.tar.gz
+scp config-DevNet.${NETWORK}.tar.gz ec2-user@${HOST}:config-bvn.tar.gz
+ssh ec2-user@${HOST} '~/accumulated-latest version'
+
+# Check if deploy is enabled
+echo ${DEPLOY} | grep -q DevNet.${NETWORK} || exit 0
+
+ssh ec2-user@${HOST} "
+    set -ex
+    screen -wipe || true
+    screen -ls | grep '\baccumulated\s' && screen -S accumulated -X stuff ^C
+    screen -ls | grep '\baccumulated-bvn\s' && screen -S accumulated-bvn -X stuff ^C
+    screen -ls | grep '\baccumulated-dn\s' && screen -S accumulated-dn -X stuff ^C
+    while screen -ls | grep -Eq '\baccumulated'; do sleep 1; done
+    rm -rf ~/.local/bin/accumulated ~/.accumulate/{bvn,dn,Node*}
+    mkdir -p ~/.local/bin ~/.accumulate/{bvn,dn,logs}
+    mv accumulated-latest ~/.local/bin/accumulated
+    tar xCf ~/.accumulate/bvn config-bvn.tar.gz Node${NODE} --strip-components 1
+    tar xCf ~/.accumulate/dn config-dn.tar.gz Node${DN_NODE} --strip-components 1
+    export PATH="'"$PATH:$HOME/.local/bin"'"
+    screen -d -m -S accumulated-bvn bash -c 'accumulated run -w ~/.accumulate/bvn 2>&1 | tee ~/.accumulate/logs/acc-bvn-$(date +%Y%m%d%H%M%S).log'
+    screen -d -m -S accumulated-dn bash -c 'accumulated run -w ~/.accumulate/dn 2>&1 | tee ~/.accumulate/logs/acc-dn-$(date +%Y%m%d%H%M%S).log'
+"


### PR DESCRIPTION
- Moves CI deployment script into its own file, for (relative) ease of testing
- Tweaks `accumulated init` to allow for disabling the website
- Updates CI to deploy configuration to `~/.accumulated/bvn` instead of `~/.accumulated/Node#`
- Updates CI to not delete `~/.accumulated` and write logs to `~/.accumulated/logs`
- Updates CI to deploy DevNet DN