### PR TITLE
Migrate CLI tx create to API v2

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path"
 	"time"
 
 	"github.com/AccumulateNetwork/jsonrpc2/v15"
@@ -32,4 +34,20 @@ func (c *APIClient) Request(ctx context.Context,
 		fmt.Println("accumulated:", c.Server)
 	}
 	return c.Client.Request(ctx, c.Server, method, params, result)
+}
+
+// RequestV2 makes request to API server (version 2)
+func (c *APIClient) RequestV2(ctx context.Context,
+	method string, params, result interface{}) error {
+
+	serverUrl, err := url.Parse(c.Server)
+	if err != nil {
+		return err
+	}
+	serverUrl.Path = path.Join(serverUrl.Path, "..", "v2")
+	server := serverUrl.String()
+	if c.DebugRequest {
+		fmt.Println("accumulated:", server)
+	}
+	return c.Client.Request(ctx, server, method, params, result)
 }

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	api2 "github.com/AccumulateNetwork/accumulate/internal/api/v2"
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	"github.com/AccumulateNetwork/accumulate/types"
 	acmeapi "github.com/AccumulateNetwork/accumulate/types/api"
@@ -151,7 +152,7 @@ func GetTXHistory(accountUrl string, s string, e string) (string, error) {
 
 func CreateTX(sender string, args []string) (string, error) {
 	//sender string, receiver string, amount string
-	var res acmeapi.APIDataResponse
+	var res api2.TxResponse
 	var err error
 	u, err := url.Parse(sender)
 	if err != nil {
@@ -195,19 +196,14 @@ func CreateTX(sender string, args []string) (string, error) {
 	}
 
 	nonce := uint64(time.Now().Unix())
-	params, err := prepareGenTx(data, dataBinary, u, si, pk, nonce)
+	params, err := prepareGenTxV2(data, dataBinary, u, si, pk, nonce)
 	if err != nil {
 		return "", err
 	}
 
-	if err := Client.Request(context.Background(), "token-tx-create", params, &res); err != nil {
+	if err := Client.RequestV2(context.Background(), "send-tokens", params, &res); err != nil {
 		return PrintJsonRpcError(err)
 	}
 
-	ar := ActionResponse{}
-	err = json.Unmarshal(*res.Data, &ar)
-	if err != nil {
-		return "", fmt.Errorf("error unmarshalling create adi result")
-	}
-	return ar.Print()
+	return ActionResponseFrom(&res).Print()
 }

--- a/internal/abci/accumulator.go
+++ b/internal/abci/accumulator.go
@@ -333,11 +333,11 @@ func (app *Accumulator) CheckTx(req abci.RequestCheckTx) (rct abci.ResponseCheck
 			u2 = u.String()
 		}
 		sentry.CaptureException(err)
-		app.logger.Info("Check failed", "type", sub.TransactionType().Name(), "tx", txHash, "error", err)
+		app.logger.Info("Check failed", "type", sub.TransactionType().Name(), "tx", txHash, "error", customErr)
 		ret.Code = uint32(customErr.Code)
 		ret.GasWanted = 0
 		ret.GasUsed = 0
-		ret.Log = fmt.Sprintf("%s check of %s transaction failed: %v", u2, sub.TransactionType().Name(), err)
+		ret.Log = fmt.Sprintf("%s check of %s transaction failed: %v", u2, sub.TransactionType().Name(), customErr)
 		return ret
 	}
 
@@ -385,10 +385,10 @@ func (app *Accumulator) DeliverTx(req abci.RequestDeliverTx) (rdt abci.ResponseD
 			u2 = u.String()
 		}
 		sentry.CaptureException(err)
-		app.logger.Info("Deliver failed", "type", sub.TransactionType().Name(), "tx", txHash, "error", err)
+		app.logger.Info("Deliver failed", "type", sub.TransactionType().Name(), "tx", txHash, "error", customErr)
 		ret.Code = uint32(customErr.Code)
 		//we don't care about failure as far as tendermint is concerned, so we should place the log in the pending
-		ret.Log = fmt.Sprintf("%s delivery of %s transaction failed: %v", u2, sub.TransactionType().Name(), err)
+		ret.Log = fmt.Sprintf("%s delivery of %s transaction failed: %v", u2, sub.TransactionType().Name(), customErr)
 		return ret
 	}
 

--- a/internal/api/v2/jrpc.go
+++ b/internal/api/v2/jrpc.go
@@ -101,7 +101,7 @@ func NewJrpc(opts JrpcOptions) (*JrpcMethods, error) {
 		"create-key-page":      m.ExecuteWith(func() PL { return new(protocol.CreateSigSpec) }),
 		"create-token":         m.ExecuteWith(func() PL { return new(protocol.CreateToken) }),
 		"create-token-account": m.ExecuteWith(func() PL { return new(protocol.TokenAccountCreate) }),
-		"send-tokens":          m.ExecuteWith(func() PL { return new(api.TokenTx) }),
+		"send-tokens":          m.ExecuteWith(func() PL { return new(api.TokenTx) }, "From", "To"),
 		"add-credits":          m.ExecuteWith(func() PL { return new(protocol.AddCredits) }),
 		"update-key-page":      m.ExecuteWith(func() PL { return new(protocol.UpdateKeyPage) }),
 	}

--- a/internal/api/v2/jrpc_utils.go
+++ b/internal/api/v2/jrpc_utils.go
@@ -2,16 +2,21 @@ package api
 
 import "encoding/json"
 
-func (m *JrpcMethods) parse(params json.RawMessage, target interface{}) error {
+func (m *JrpcMethods) parse(params json.RawMessage, target interface{}, validateFields ...string) error {
 	err := json.Unmarshal(params, target)
 	if err != nil {
 		return validatorError(err)
 	}
 
-	// validate URL
-	err = m.validate.Struct(target)
-	if err != nil {
-		return validatorError(err)
+	// validate fields
+	if len(validateFields) == 0 {
+		if err = m.validate.Struct(target); err != nil {
+			return validatorError(err)
+		}
+	} else {
+		if err = m.validate.StructPartial(target, validateFields...); err != nil {
+			return validatorError(err)
+		}
 	}
 
 	return nil

--- a/internal/api/v2/types.yml
+++ b/internal/api/v2/types.yml
@@ -57,6 +57,7 @@ KeyPage:
     type: uvarint
   - name: Index
     type: uvarint
+    optional: true
 
 Signer:
   non-binary: true

--- a/internal/api/v2/types_gen.go
+++ b/internal/api/v2/types_gen.go
@@ -17,7 +17,7 @@ type ChainIdQuery struct {
 
 type KeyPage struct {
 	Height uint64 `json:"height,omitempty" form:"height" query:"height" validate:"required"`
-	Index  uint64 `json:"index,omitempty" form:"index" query:"index" validate:"required"`
+	Index  uint64 `json:"index,omitempty" form:"index" query:"index"`
 }
 
 type MerkleState struct {

--- a/internal/api/v2/types_gen.go
+++ b/internal/api/v2/types_gen.go
@@ -257,6 +257,7 @@ func (v *ChainIdQuery) UnmarshalJSON(data []byte) error {
 	u := struct {
 		ChainId *string `json:"chainId,omitempty"`
 	}{}
+	u.ChainId = encoding.BytesToJSON(v.ChainId)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -273,6 +274,11 @@ func (v *MerkleState) UnmarshalJSON(data []byte) error {
 		Count uint64    `json:"count,omitempty"`
 		Roots []*string `json:"roots,omitempty"`
 	}{}
+	u.Count = v.Count
+	u.Roots = make([]*string, len(v.Roots))
+	for i, x := range v.Roots {
+		u.Roots[i] = encoding.BytesToJSON(x)
+	}
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -293,6 +299,8 @@ func (v *MetricsQuery) UnmarshalJSON(data []byte) error {
 		Metric   string      `json:"metric,omitempty"`
 		Duration interface{} `json:"duration,omitempty"`
 	}{}
+	u.Metric = v.Metric
+	u.Duration = encoding.DurationToJSON(v.Duration)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -317,6 +325,15 @@ func (v *QueryResponse) UnmarshalJSON(data []byte) error {
 		Sig         *string      `json:"sig,omitempty"`
 		Status      interface{}  `json:"status,omitempty"`
 	}{}
+	u.Type = v.Type
+	u.MerkleState = v.MerkleState
+	u.Data = v.Data
+	u.Sponsor = v.Sponsor
+	u.KeyPage = v.KeyPage
+	u.Txid = encoding.BytesToJSON(v.Txid)
+	u.Signer = v.Signer
+	u.Sig = encoding.BytesToJSON(v.Sig)
+	u.Status = v.Status
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -345,6 +362,8 @@ func (v *Signer) UnmarshalJSON(data []byte) error {
 		PublicKey *string `json:"publicKey,omitempty"`
 		Nonce     uint64  `json:"nonce,omitempty"`
 	}{}
+	u.PublicKey = encoding.BytesToJSON(v.PublicKey)
+	u.Nonce = v.Nonce
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -363,6 +382,9 @@ func (v *TokenDeposit) UnmarshalJSON(data []byte) error {
 		Amount uint64  `json:"amount,omitempty"`
 		Txid   *string `json:"txid,omitempty"`
 	}{}
+	u.Url = v.Url
+	u.Amount = v.Amount
+	u.Txid = encoding.BytesToJSON(v.Txid)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -380,6 +402,7 @@ func (v *TxIdQuery) UnmarshalJSON(data []byte) error {
 	u := struct {
 		Txid *string `json:"txid,omitempty"`
 	}{}
+	u.Txid = encoding.BytesToJSON(v.Txid)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -400,6 +423,12 @@ func (v *TxRequest) UnmarshalJSON(data []byte) error {
 		KeyPage   KeyPage     `json:"keyPage,omitempty"`
 		Payload   interface{} `json:"payload,omitempty"`
 	}{}
+	u.CheckOnly = v.CheckOnly
+	u.Sponsor = v.Sponsor
+	u.Signer = v.Signer
+	u.Signature = encoding.BytesToJSON(v.Signature)
+	u.KeyPage = v.KeyPage
+	u.Payload = v.Payload
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -424,6 +453,11 @@ func (v *TxResponse) UnmarshalJSON(data []byte) error {
 		Message   string  `json:"message,omitempty"`
 		Delivered bool    `json:"delivered,omitempty"`
 	}{}
+	u.Txid = encoding.BytesToJSON(v.Txid)
+	u.Hash = encoding.ChainToJSON(v.Hash)
+	u.Code = v.Code
+	u.Message = v.Message
+	u.Delivered = v.Delivered
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -286,6 +286,14 @@ func run(_ *cobra.Command, args []string) {
 
 		fmt.Fprintf(w, "func (v *%s) UnmarshalJSON(data []byte) error {\t", typ.name)
 		jsonVar(w, typ, "u")
+
+		if typ.Kind == "chain" {
+			fmt.Fprintf(w, "\tu.ChainHeader = v.ChainHeader\n")
+		}
+		for _, f := range typ.Fields {
+			valueToJson(w, f, "u."+f.Name, "v."+f.Name)
+		}
+
 		fmt.Fprintf(w, "\tif err := json.Unmarshal(data, &u); err != nil {\n\t\treturn err\n\t}\n")
 
 		if typ.Kind == "chain" {

--- a/protocol/types_gen.go
+++ b/protocol/types_gen.go
@@ -2075,6 +2075,8 @@ func (v *ChainParams) UnmarshalJSON(data []byte) error {
 		Data     *string `json:"data,omitempty"`
 		IsUpdate bool    `json:"isUpdate,omitempty"`
 	}{}
+	u.Data = encoding.BytesToJSON(v.Data)
+	u.IsUpdate = v.IsUpdate
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2092,6 +2094,8 @@ func (v *CreateSigSpecGroup) UnmarshalJSON(data []byte) error {
 		Url      string   `json:"url,omitempty"`
 		SigSpecs []string `json:"sigSpecs,omitempty"`
 	}{}
+	u.Url = v.Url
+	u.SigSpecs = encoding.ChainSetToJSON(v.SigSpecs)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2109,6 +2113,8 @@ func (v *DataAccount) UnmarshalJSON(data []byte) error {
 		state.ChainHeader
 		Data *string `json:"data,omitempty"`
 	}{}
+	u.ChainHeader = v.ChainHeader
+	u.Data = encoding.BytesToJSON(v.Data)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2128,6 +2134,10 @@ func (v *IdentityCreate) UnmarshalJSON(data []byte) error {
 		KeyBookName string  `json:"keyBookName,omitempty"`
 		KeyPageName string  `json:"keyPageName,omitempty"`
 	}{}
+	u.Url = v.Url
+	u.PublicKey = encoding.BytesToJSON(v.PublicKey)
+	u.KeyBookName = v.KeyBookName
+	u.KeyPageName = v.KeyPageName
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2147,6 +2157,8 @@ func (v *KeySpec) UnmarshalJSON(data []byte) error {
 		PublicKey *string `json:"publicKey,omitempty"`
 		Nonce     uint64  `json:"nonce,omitempty"`
 	}{}
+	u.PublicKey = encoding.BytesToJSON(v.PublicKey)
+	u.Nonce = v.Nonce
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2163,6 +2175,7 @@ func (v *KeySpecParams) UnmarshalJSON(data []byte) error {
 	u := struct {
 		PublicKey *string `json:"publicKey,omitempty"`
 	}{}
+	u.PublicKey = encoding.BytesToJSON(v.PublicKey)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2179,6 +2192,8 @@ func (v *LiteDataAccount) UnmarshalJSON(data []byte) error {
 		state.ChainHeader
 		Data *string `json:"data,omitempty"`
 	}{}
+	u.ChainHeader = v.ChainHeader
+	u.Data = encoding.BytesToJSON(v.Data)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2196,6 +2211,8 @@ func (v *MetricsRequest) UnmarshalJSON(data []byte) error {
 		Metric   string      `json:"metric,omitempty"`
 		Duration interface{} `json:"duration,omitempty"`
 	}{}
+	u.Metric = v.Metric
+	u.Duration = encoding.DurationToJSON(v.Duration)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2213,6 +2230,8 @@ func (v *SigSpecGroup) UnmarshalJSON(data []byte) error {
 		state.ChainHeader
 		SigSpecs []string `json:"sigSpecs,omitempty"`
 	}{}
+	u.ChainHeader = v.ChainHeader
+	u.SigSpecs = encoding.ChainSetToJSON(v.SigSpecs)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2230,6 +2249,8 @@ func (v *SyntheticCreateChain) UnmarshalJSON(data []byte) error {
 		Cause  string        `json:"cause,omitempty"`
 		Chains []ChainParams `json:"chains,omitempty"`
 	}{}
+	u.Cause = encoding.ChainToJSON(v.Cause)
+	u.Chains = v.Chains
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2247,6 +2268,8 @@ func (v *SyntheticDepositCredits) UnmarshalJSON(data []byte) error {
 		Cause  string `json:"cause,omitempty"`
 		Amount uint64 `json:"amount,omitempty"`
 	}{}
+	u.Cause = encoding.ChainToJSON(v.Cause)
+	u.Amount = v.Amount
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2263,6 +2286,7 @@ func (v *SyntheticWriteData) UnmarshalJSON(data []byte) error {
 	u := struct {
 		Data *string `json:"data,omitempty"`
 	}{}
+	u.Data = encoding.BytesToJSON(v.Data)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2281,6 +2305,10 @@ func (v *TxSynthRef) UnmarshalJSON(data []byte) error {
 		Url   string `json:"url,omitempty"`
 		TxRef string `json:"txRef,omitempty"`
 	}{}
+	u.Type = v.Type
+	u.Hash = encoding.ChainToJSON(v.Hash)
+	u.Url = v.Url
+	u.TxRef = encoding.ChainToJSON(v.TxRef)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2305,6 +2333,9 @@ func (v *UpdateKeyPage) UnmarshalJSON(data []byte) error {
 		Key       *string          `json:"key,omitempty"`
 		NewKey    *string          `json:"newKey,omitempty"`
 	}{}
+	u.Operation = v.Operation
+	u.Key = encoding.BytesToJSON(v.Key)
+	u.NewKey = encoding.BytesToJSON(v.NewKey)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2326,6 +2357,7 @@ func (v *WriteData) UnmarshalJSON(data []byte) error {
 	u := struct {
 		Data *string `json:"data,omitempty"`
 	}{}
+	u.Data = encoding.BytesToJSON(v.Data)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -2342,6 +2374,8 @@ func (v *WriteDataTo) UnmarshalJSON(data []byte) error {
 		Recipient string  `json:"recipient,omitempty"`
 		Data      *string `json:"data,omitempty"`
 	}{}
+	u.Recipient = v.Recipient
+	u.Data = encoding.BytesToJSON(v.Data)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}

--- a/types/state/types_gen.go
+++ b/types/state/types_gen.go
@@ -191,6 +191,10 @@ func (v *AnchorMetadata) UnmarshalJSON(data []byte) error {
 		Timestamp      time.Time `json:"timestamp,omitempty"`
 		Chains         []string  `json:"chains,omitempty"`
 	}{}
+	u.Index = v.Index
+	u.PreviousHeight = v.PreviousHeight
+	u.Timestamp = v.Timestamp
+	u.Chains = encoding.ChainSetToJSON(v.Chains)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -211,6 +215,12 @@ func (v *Object) UnmarshalJSON(data []byte) error {
 		Height uint64    `json:"height,omitempty"`
 		Roots  []*string `json:"roots,omitempty"`
 	}{}
+	u.Entry = encoding.BytesToJSON(v.Entry)
+	u.Height = v.Height
+	u.Roots = make([]*string, len(v.Roots))
+	for i, x := range v.Roots {
+		u.Roots[i] = encoding.BytesToJSON(x)
+	}
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Fix ABCI error reporting
- Fix JSON unmarshaling of API v2 TxRequest when the Payload field is set
- Fix unmarshalling and validating for API v2 execute methods
- Fix issue where setting the key page index to 0 would result in validation errors
- Migrate cli tx create to API v2

To validate, run `cli -d tx create ${SENDER} ${RECIPIENT} ${AMOUNT}` and verify that the server URL ends in /v2 and the transaction succeeds.