### PR TITLE
Add a --pretend flag to the CLI

### DIFF
--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -16,6 +16,7 @@ var (
 	Client         = client.NewAPIClient()
 	Db             db.DB
 	WantJsonOutput = false
+	TxPretend      = false
 )
 
 var currentUser = func() *user.User {
@@ -45,6 +46,7 @@ func InitRootCmd(database db.DB) *cobra.Command {
 	flags.DurationVarP(&Client.Timeout, "timeout", "t", 5*time.Second, "Timeout for all API requests (i.e. 10s, 1m)")
 	flags.BoolVarP(&Client.DebugRequest, "debug", "d", false, "Print accumulated API calls")
 	flags.BoolVarP(&WantJsonOutput, "json", "j", false, "print outputs as json")
+	flags.BoolVarP(&TxPretend, "pretend", "n", false, "Enables check-only mode for transactions")
 
 	//add the commands
 	cmd.AddCommand(accountCmd)

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -139,6 +139,10 @@ func prepareGenTxV2(jsonPayload, binaryPayload []byte, actor *url2.URL, si *tran
 
 	params := &api2.TxRequest{}
 
+	if TxPretend {
+		params.CheckOnly = true
+	}
+
 	// TODO The payload field can be set equal to the struct, without marshalling first
 	params.Payload = json.RawMessage(jsonPayload)
 	params.Signer.PublicKey = privKey[32:]


### PR DESCRIPTION
Add a flag to the CLI that sets `checkOnly` for API v2 transaction requests. For CLI commands that have been migrated to API v2, this will validate the transaction without submitting it.

To verify, run `cli tx create ${SENDER} ${RECIPIENT} ${AMOUNT}` and verify that it worked (`cli account get ${RECIPIENT}`). Then send `cli tx create --pretend ...` and verify that the request succeded, but the recipient account balance did not change.