### PR TITLE
Correct synthetic transaction production

### DIFF
--- a/cmd/cli/cmd/adi_test.go
+++ b/cmd/cli/cmd/adi_test.go
@@ -35,14 +35,14 @@ func testCase2_1(t *testing.T, tc *testCmd) {
 	testCase5_1(t, tc)
 
 	//need to wait a sec to make sure faucet tx settles
-	time.Sleep(time.Second)
+	time.Sleep(10 * time.Second)
 
 	commandLine := fmt.Sprintf("adi create %s acc://RedWagon red1", liteAccounts[0])
 	_, err := tc.execute(t, commandLine)
 	require.NoError(t, err)
 
 	//need to wait 2 secs to make sure adi create settles
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	//if this doesn't fail, then adi is created
 	_, err = tc.execute(t, "adi directory acc://RedWagon")
@@ -115,7 +115,7 @@ func testCase2_6(t *testing.T, tc *testCmd) {
 
 	t.Log(r)
 	//need to wait 2 secs to make sure adi create settles
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	//if this doesn't fail, then adi is created
 	r, err = tc.execute(t, "adi directory acc://Redstone")

--- a/cmd/cli/cmd/faucet_test.go
+++ b/cmd/cli/cmd/faucet_test.go
@@ -32,7 +32,7 @@ func testCase5_1(t *testing.T, tc *testCmd) {
 	}
 
 	//wait for settlement
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	for i := range liteAccounts {
 		//now query the account to make sure each account has 10 acme.

--- a/cmd/cli/cmd/page_test.go
+++ b/cmd/cli/cmd/page_test.go
@@ -36,7 +36,7 @@ func testCase4_1(t *testing.T, tc *testCmd) {
 
 	t.Log(r)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 }
 
 //testCase4_2 Create a key book from unbounded key pages
@@ -49,7 +49,7 @@ func testCase4_2(t *testing.T, tc *testCmd) {
 
 	t.Log(r)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 }
 
 //testCase4_3 Add a key to a key page
@@ -66,7 +66,7 @@ func testCase4_3(t *testing.T, tc *testCmd) {
 	//
 	//t.Log(r)
 	//
-	//time.Sleep(2 * time.Second)
+	//time.Sleep(10 * time.Second)
 }
 
 //testCase4_4 Create additional key pages sponsored by a book
@@ -79,7 +79,7 @@ func testCase4_4(t *testing.T, tc *testCmd) {
 
 	t.Log(r)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 }
 
 //testCase4_5 Create an adi token account bound to a key book
@@ -92,7 +92,7 @@ func testCase4_5(t *testing.T, tc *testCmd) {
 
 	t.Log(r)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 }
 
 //testCase4_6 Delete a key in a key page
@@ -110,7 +110,7 @@ func testCase4_6(t *testing.T, tc *testCmd) {
 	//
 	//t.Log(r)
 	//
-	//time.Sleep(2 * time.Second)
+	//time.Sleep(10 * time.Second)
 }
 
 //testCase4_7 update a key in a key page
@@ -128,7 +128,7 @@ func testCase4_7(t *testing.T, tc *testCmd) {
 	//
 	//t.Log(r)
 	//
-	//time.Sleep(2 * time.Second)
+	//time.Sleep(10 * time.Second)
 }
 
 //testCase4_8 Sign a transaction with a secondary key page
@@ -142,12 +142,12 @@ func testCase4_8(t *testing.T, tc *testCmd) {
 	//r, err := tc.execute(t, commandLine)
 	//require.NoError(t, err)
 	//
-	//time.Sleep(4 * time.Second)
+	//time.Sleep(10 * time.Second)
 	//commandLine = fmt.Sprintf("tx create acc://RedWagon/acct2 red3 1 1 acc://Redwagon/acct 1.1234")
 	//r, err = tc.execute(t, commandLine)
 	//require.NoError(t, err)
 	//
 	//t.Log(r)
 	//
-	//time.Sleep(2 * time.Second)
+	//time.Sleep(10 * time.Second)
 }

--- a/cmd/cli/cmd/root_test.go
+++ b/cmd/cli/cmd/root_test.go
@@ -78,8 +78,8 @@ func (tm *testMatrixTests) execute(t *testing.T, tc *testCmd) {
 
 	//execute the tests
 	for _, f := range testMatrix {
-		t.Log(GetFunctionName(f))
-		f(t, tc)
+		name := strings.Split(GetFunctionName(f), ".")
+		t.Run(name[len(name)-1], func(t *testing.T) { f(t, tc) })
 	}
 }
 
@@ -214,7 +214,7 @@ func (c *testCmd) initalize(t *testing.T) {
 	c.rootCmd.PersistentPostRun = nil
 
 	c.jsonRpcPort, c.restPort = NewTestBVNN(t, defaultWorkDir)
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	t.Cleanup(func() {
 		os.Remove(defaultWorkDir)

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -24,22 +24,38 @@ import (
 // Version is the version of the ABCI applications.
 const Version uint64 = 0x1
 
+// BeginBlockRequest is the input parameter to Chain.BeginBlock.
 type BeginBlockRequest struct {
 	IsLeader bool
 	Height   int64
 	Time     time.Time
 }
 
+// BeginBlockResponse is the return value of Chain.BeginBlock.
+type BeginBlockResponse struct {
+	SynthTxns []SynthTxnReference
+}
+
+// SynthTxnReference is a reference to a produced synthetic transaction.
+type SynthTxnReference struct {
+	Type  uint64   `json:"type,omitempty" form:"type" query:"type" validate:"required"`
+	Hash  [32]byte `json:"hash,omitempty" form:"hash" query:"hash" validate:"required"`
+	Url   string   `json:"url,omitempty" form:"url" query:"url" validate:"required,acc-url"`
+	TxRef [32]byte `json:"txRef,omitempty" form:"txRef" query:"txRef" validate:"required"`
+}
+
+// EndBlockRequest is the input parameter to Chain.EndBlock
 type EndBlockRequest struct{}
 
+// Chain is the interface for the Accumulate transaction (chain) validator.
 type Chain interface {
 	Query(*apiQuery.Query) (k, v []byte, err *protocol.Error)
 
 	InitChain(state []byte) error
 
-	BeginBlock(BeginBlockRequest)
+	BeginBlock(BeginBlockRequest) (BeginBlockResponse, error)
 	CheckTx(*transactions.GenTransaction) *protocol.Error
-	DeliverTx(*transactions.GenTransaction) (*protocol.TxResult, *protocol.Error)
+	DeliverTx(*transactions.GenTransaction) *protocol.Error
 	EndBlock(EndBlockRequest)
 	Commit() ([]byte, error)
 }

--- a/internal/abci/accumulator.go
+++ b/internal/abci/accumulator.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/AccumulateNetwork/accumulate"
@@ -15,7 +16,6 @@ import (
 	"github.com/AccumulateNetwork/accumulate/protocol"
 	_ "github.com/AccumulateNetwork/accumulate/smt/pmt"
 	"github.com/AccumulateNetwork/accumulate/smt/storage"
-	"github.com/AccumulateNetwork/accumulate/types"
 	apiQuery "github.com/AccumulateNetwork/accumulate/types/api/query"
 	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
 	"github.com/getsentry/sentry-go"
@@ -77,27 +77,37 @@ func (app *Accumulator) OnFatal(f func(error)) {
 	app.onFatal = f
 }
 
+// fatal is called when a fatal error occurs. If fatal is called, all subsequent
+// transactions will fail with CodeDidPanic.
+func (app *Accumulator) fatal(err error) {
+	app.didPanic = true
+
+	app.logger.Error("Fatal error", "error", err, "stack", debug.Stack())
+	sentry.CaptureException(err)
+
+	if app.onFatal != nil {
+		app.onFatal(err)
+	}
+}
+
+// recover will recover from a panic. If a panic occurs, it is passed to fatal
+// and code is set to CodeDidPanic (unless the pointer is nil).
 func (app *Accumulator) recover(code *uint32) {
 	r := recover()
 	if r == nil {
 		return
 	}
 
-	app.didPanic = true
-	if code != nil {
-		*code = protocol.CodeUnknownError
-	}
-
 	err, ok := r.(error)
 	if ok {
-		err = fmt.Errorf("did panic: %w", err)
+		err = fmt.Errorf("panicked: %w", err)
 	} else {
-		err = fmt.Errorf("did panic: %v", r)
+		err = fmt.Errorf("panicked: %v", r)
 	}
+	app.fatal(err)
 
-	sentry.CaptureException(err)
-	if app.onFatal != nil {
-		app.onFatal(err)
+	if code != nil {
+		*code = protocol.CodeDidPanic
 	}
 }
 
@@ -234,12 +244,18 @@ func (app *Accumulator) InitChain(req abci.RequestInitChain) abci.ResponseInitCh
 func (app *Accumulator) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	defer app.recover(nil)
 
+	var ret abci.ResponseBeginBlock
+
 	//Identify the leader for this block, if we are the proposer... then we are the leader.
-	app.chain.BeginBlock(BeginBlockRequest{
+	_, err := app.chain.BeginBlock(BeginBlockRequest{
 		IsLeader: bytes.Equal(app.address.Bytes(), req.Header.GetProposerAddress()),
 		Height:   req.Header.Height,
 		Time:     req.Header.Time,
 	})
+	if err != nil {
+		app.fatal(err)
+		return ret
+	}
 
 	app.timer = time.Now()
 
@@ -268,7 +284,7 @@ func (app *Accumulator) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBegi
 
 	*/
 
-	return abci.ResponseBeginBlock{}
+	return ret
 }
 
 // CheckTx implements github.com/tendermint/tendermint/abci/types.Application.
@@ -313,7 +329,7 @@ func (app *Accumulator) CheckTx(req abci.RequestCheckTx) (rct abci.ResponseCheck
 		if e2 == nil {
 			u2 = u.String()
 		}
-		sentry.CaptureException(err)
+		sentry.CaptureException(customErr)
 		app.logger.Info("Check failed", "type", sub.TransactionType().Name(), "tx", txHash, "error", customErr)
 		ret.Code = uint32(customErr.Code)
 		ret.GasWanted = 0
@@ -357,7 +373,7 @@ func (app *Accumulator) DeliverTx(req abci.RequestDeliverTx) (rdt abci.ResponseD
 	}
 
 	//run through the validation node
-	r, customErr := app.chain.DeliverTx(sub)
+	customErr := app.chain.DeliverTx(sub)
 
 	if customErr != nil {
 		u2 := sub.SigInfo.URL
@@ -365,24 +381,12 @@ func (app *Accumulator) DeliverTx(req abci.RequestDeliverTx) (rdt abci.ResponseD
 		if e2 == nil {
 			u2 = u.String()
 		}
-		sentry.CaptureException(err)
+		sentry.CaptureException(customErr)
 		app.logger.Info("Deliver failed", "type", sub.TransactionType().Name(), "tx", txHash, "error", customErr)
 		ret.Code = uint32(customErr.Code)
 		//we don't care about failure as far as tendermint is concerned, so we should place the log in the pending
 		ret.Log = fmt.Sprintf("%s delivery of %s transaction failed: %v", u2, sub.TransactionType().Name(), customErr)
 		return ret
-	}
-
-	for _, syn := range r.SyntheticTxs {
-		ret.Events = append(ret.Events, abci.Event{
-			Type: "accSyn",
-			Attributes: []abci.EventAttribute{
-				{Key: "type", Value: types.TxType(syn.Type).String()},
-				{Key: "hash", Value: fmt.Sprintf("%X", syn.Hash)},
-				{Key: "url", Value: syn.Url},
-				{Key: "txRef", Value: fmt.Sprintf("%X", syn.TxRef)},
-			},
-		})
 	}
 
 	//now we need to store the data returned by the validator and feed into accumulator
@@ -430,8 +434,7 @@ func (app *Accumulator) Commit() (resp abci.ResponseCommit) {
 	resp.Data = mdRoot
 
 	if err != nil {
-		sentry.CaptureException(err)
-		app.logger.Error(err.Error(), "operation", "commit")
+		app.fatal(err)
 		return
 	}
 

--- a/internal/abci/accumulator_test.go
+++ b/internal/abci/accumulator_test.go
@@ -115,7 +115,7 @@ func (s *AccumulatorTestSuite) TestDeliverTx() {
 		data, err := tx.Marshal()
 		s.Require().NoError(err)
 
-		s.Chain().EXPECT().DeliverTx(gomock.Any()).Return(new(protocol.TxResult), nil)
+		s.Chain().EXPECT().DeliverTx(gomock.Any()).Return(nil)
 
 		resp := s.App(nil).DeliverTx(tmabci.RequestDeliverTx{Tx: data})
 		s.Require().Zero(resp.Code)
@@ -133,7 +133,7 @@ func (s *AccumulatorTestSuite) TestDeliverTx() {
 		data, err := tx.Marshal()
 		s.Require().NoError(err)
 
-		s.Chain().EXPECT().DeliverTx(gomock.Any()).Return(nil, &protocol.Error{Code: protocol.CodeUnknownError, Message: fmt.Errorf("error")})
+		s.Chain().EXPECT().DeliverTx(gomock.Any()).Return(&protocol.Error{Code: protocol.CodeUnknownError, Message: fmt.Errorf("error")})
 
 		resp := s.App(nil).DeliverTx(tmabci.RequestDeliverTx{Tx: data})
 		s.Require().NotZero(resp.Code)

--- a/internal/abci/e2e_statedb_test.go
+++ b/internal/abci/e2e_statedb_test.go
@@ -21,12 +21,13 @@ func TestStateDBConsistency(t *testing.T) {
 	sdb := new(state.StateDB)
 	require.NoError(t, sdb.Load(db, true))
 
-	n := createApp(t, sdb, crypto.Address{}, "error", false)
+	n := createApp(t, sdb, crypto.Address{}, "error", true)
 	n.testAnonTx(10)
 
 	height, err := sdb.BlockIndex()
 	require.NoError(t, err)
 	rootHash := sdb.RootHash()
+	n.client.Shutdown()
 
 	// Reopen the database
 	sdb = new(state.StateDB)

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -122,7 +122,7 @@ func TestJsonRpcAnonToken(t *testing.T) {
 	}
 
 	//wait 3 seconds for the transaction to process for the block to complete.
-	time.Sleep(10 * time.Second)
+	time.Sleep(time.Second)
 
 	queryTokenUrl := addrList[1]
 	resp, err := query.GetTokenAccount(queryTokenUrl)
@@ -294,7 +294,7 @@ func TestFaucet(t *testing.T) {
 	fmt.Println(string(data))
 
 	//allow the transaction to settle.
-	time.Sleep(3 * time.Second)
+	time.Sleep(time.Second)
 
 	//readback the result.
 	resp, err := query.GetChainStateByUrl(string(req.URL))
@@ -358,7 +358,7 @@ func TestTransactionHistory(t *testing.T) {
 	fmt.Println(string(data))
 
 	//allow the transaction to settle.
-	time.Sleep(3 * time.Second)
+	time.Sleep(time.Second)
 
 	jd, err := json.Marshal(res)
 	if err != nil {
@@ -423,7 +423,7 @@ func TestFaucetTransactionHistory(t *testing.T) {
 	}
 
 	//allow the transaction to settle.
-	time.Sleep(3 * time.Second)
+	time.Sleep(time.Second)
 
 	jd, err := json.Marshal(res)
 	require.NoError(t, err)
@@ -620,7 +620,7 @@ func TestFaucetReplay(t *testing.T) {
 	fmt.Printf("%s\n", *res.Data)
 
 	// Allow the transaction to settle.
-	time.Sleep(3 * time.Second)
+	time.Sleep(time.Second)
 
 	// Read back the result.
 	resp, err := query.GetChainStateByUrl(destAccount)

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/AccumulateNetwork/accumulate/config"
 	. "github.com/AccumulateNetwork/accumulate/internal/api"
@@ -43,6 +44,7 @@ func startBVC(t *testing.T, dir string) (*state.StateDB, *privval.FilePV, *Query
 	require.NoError(t, err)                                                                //
 	cfg.Accumulate.WebsiteEnabled = false                                                  // Disable the website
 	cfg.Instrumentation.Prometheus = false                                                 // Disable prometheus: https://github.com/tendermint/tendermint/issues/7076
+	cfg.Consensus.TimeoutCommit = time.Second / 10                                         // ~10 blocks per second
 	require.NoError(t, config.Store(cfg))                                                  //
 	node, sdb, pv, err := acctesting.NewBVCNode(nodeDir, false, nil, newLogger, t.Cleanup) // Initialize
 	require.NoError(t, err)                                                                //

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -1,19 +1,17 @@
 package chain
 
 import (
-	"crypto/ed25519"
 	"math/big"
 
-	accapi "github.com/AccumulateNetwork/accumulate/internal/api"
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	"github.com/AccumulateNetwork/accumulate/types"
 	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
 	"github.com/AccumulateNetwork/accumulate/types/state"
-	"github.com/tendermint/tendermint/libs/log"
 )
 
-func NewBlockValidatorExecutor(query *accapi.Query, db *state.StateDB, logger log.Logger, key ed25519.PrivateKey) (*Executor, error) {
-	return NewExecutor(query, db, logger, key,
+// NewBlockValidatorExecutor creates a new Executor for a block validator node.
+func NewBlockValidatorExecutor(opts ExecutorOptions) (*Executor, error) {
+	return NewExecutor(opts,
 		CreateIdentity{},
 		WithdrawTokens{},
 		CreateTokenAccount{},
@@ -24,14 +22,15 @@ func NewBlockValidatorExecutor(query *accapi.Query, db *state.StateDB, logger lo
 		SyntheticCreateChain{},
 		SyntheticTokenDeposit{},
 		SyntheticDepositCredits{},
+		SyntheticSignTransactions{},
 
 		// TODO Only for TestNet
 		AcmeFaucet{},
 	)
 }
 
-func NewDirectoryExecutor(query *accapi.Query, db *state.StateDB, logger log.Logger, key ed25519.PrivateKey) (*Executor, error) {
-	return NewExecutor(query, db, logger, key) // TODO Add DN validators
+func NewDirectoryExecutor(opts ExecutorOptions) (*Executor, error) {
+	return NewExecutor(opts) // TODO Add DN validators
 }
 
 // TxExecutor executes a specific type of transaction.

--- a/internal/chain/executor.go
+++ b/internal/chain/executor.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/json"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/AccumulateNetwork/accumulate/internal/abci"
 	accapi "github.com/AccumulateNetwork/accumulate/internal/api"
+	apiv2 "github.com/AccumulateNetwork/accumulate/internal/api/v2"
 	"github.com/AccumulateNetwork/accumulate/internal/logging"
 	"github.com/AccumulateNetwork/accumulate/protocol"
 	"github.com/AccumulateNetwork/accumulate/smt/common"
@@ -29,6 +31,7 @@ type Executor struct {
 	db        *state.StateDB
 	key       ed25519.PrivateKey
 	query     *accapi.Query
+	local     apiv2.ABCIBroadcastClient
 	executors map[types.TxType]TxExecutor
 
 	wg      *sync.WaitGroup
@@ -43,15 +46,24 @@ type Executor struct {
 
 var _ abci.Chain = (*Executor)(nil)
 
-func NewExecutor(query *accapi.Query, db *state.StateDB, logger log.Logger, key ed25519.PrivateKey, executors ...TxExecutor) (*Executor, error) {
+type ExecutorOptions struct {
+	Query  *accapi.Query
+	DB     *state.StateDB
+	Logger log.Logger
+	Key    ed25519.PrivateKey
+	Local  apiv2.ABCIBroadcastClient
+}
+
+func NewExecutor(opts ExecutorOptions, executors ...TxExecutor) (*Executor, error) {
 	m := new(Executor)
-	m.db = db
+	m.db = opts.DB
 	m.executors = map[types.TxType]TxExecutor{}
-	m.key = key
+	m.key = opts.Key
 	m.wg = new(sync.WaitGroup)
 	m.mu = new(sync.Mutex)
-	m.query = query
-	m.logger = logger.With("module", "executor")
+	m.query = opts.Query
+	m.logger = opts.Logger.With("module", "executor")
+	m.local = opts.Local
 
 	for _, x := range executors {
 		if _, ok := m.executors[x.Type()]; ok {
@@ -60,14 +72,14 @@ func NewExecutor(query *accapi.Query, db *state.StateDB, logger log.Logger, key 
 		m.executors[x.Type()] = x
 	}
 
-	height, err := db.BlockIndex()
+	height, err := m.db.BlockIndex()
 	if errors.Is(err, storage.ErrNotFound) {
 		height = 0
 	} else if err != nil {
 		return nil, err
 	}
 
-	m.logger.Info("Loaded", "height", height, "hash", logging.AsHex(db.RootHash()))
+	m.logger.Info("Loaded", "height", height, "hash", logging.AsHex(m.db.RootHash()))
 	return m, nil
 }
 
@@ -89,12 +101,44 @@ func (m *Executor) InitChain(state []byte) error {
 }
 
 // BeginBlock implements ./abci.Chain
-func (m *Executor) BeginBlock(req abci.BeginBlockRequest) {
+func (m *Executor) BeginBlock(req abci.BeginBlockRequest) (abci.BeginBlockResponse, error) {
 	m.leader = req.IsLeader
 	m.height = req.Height
 	m.time = req.Time
 	m.chainWG = make(map[uint64]*sync.WaitGroup, chainWGSize)
 	m.dbTx = m.db.Begin()
+
+	// In order for other BVCs to be able to validate the synthetic transaction,
+	// a wrapped signed version must be resubmitted to this BVC network and the
+	// UNSIGNED version of the transaction along with the Leader address will be
+	// stored in a SynthChain in the SMT on this BVC. The BVCs will validate the
+	// synth transaction against the receipt and EVERYONE will then send out the
+	// wrapped TX along with the proof from the directory chain. If by end block
+	// there are still unprocessed synthetic TX's the current leader takes over,
+	// invalidates the previous leader's signed tx, signs the unprocessed synth
+	// tx, and tries again with the new leader. By EVERYONE submitting the
+	// leader signed synth tx to the designated BVC network it takes advantage
+	// of the flood-fill gossip network tendermint will provide and ensure the
+	// synth transaction will be picked up.
+
+	// If we're the leader, sign synthetic transactions produced by the previous
+	// block
+	if m.leader {
+		err := m.signSynthTxns()
+		if err != nil {
+			return abci.BeginBlockResponse{}, err
+		}
+	}
+
+	// Send synthetic transactions produced in the previous block
+	txns, err := m.sendSynthTxns()
+	if err != nil {
+		return abci.BeginBlockResponse{}, err
+	}
+
+	return abci.BeginBlockResponse{
+		SynthTxns: txns,
+	}, nil
 }
 
 func (m *Executor) check(tx *transactions.GenTransaction) (*StateManager, error) {
@@ -256,7 +300,7 @@ func (m *Executor) recordTransactionError(txPending *state.PendingTransaction, c
 }
 
 // DeliverTx implements ./abci.Chain
-func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResult, *protocol.Error) {
+func (m *Executor) DeliverTx(tx *transactions.GenTransaction) *protocol.Error {
 	m.wg.Add(1)
 
 	// If this is done async (`go m.deliverTxAsync(tx)`), how would an error
@@ -272,7 +316,7 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 	defer m.wg.Done()
 
 	if tx.Transaction == nil || tx.SigInfo == nil || len(tx.ChainID) != 32 {
-		return nil, &protocol.Error{Code: protocol.CodeInvalidTxnError, Message: fmt.Errorf("malformed transaction error")}
+		return &protocol.Error{Code: protocol.CodeInvalidTxnError, Message: fmt.Errorf("malformed transaction error")}
 	}
 
 	txt := types.TxType(tx.TransactionType())
@@ -280,7 +324,7 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 	txPending := state.NewPendingTransaction(tx)
 	chainId := types.Bytes(tx.ChainID).AsBytes32()
 	if !ok {
-		return nil, m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeInvalidTxnType, Message: fmt.Errorf("unsupported TX type: %v", tx.TransactionType().Name())})
+		return m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeInvalidTxnType, Message: fmt.Errorf("unsupported TX type: %v", tx.TransactionType().Name())})
 	}
 
 	tx.TransactionHash()
@@ -299,14 +343,14 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 
 	st, err := m.check(tx)
 	if err != nil {
-		return nil, m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeCheckTxError, Message: fmt.Errorf("txn check failed : %v", err)})
+		return m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeCheckTxError, Message: fmt.Errorf("txn check failed : %v", err)})
 	}
 
 	// Validate
 	// TODO result should return a list of chainId's the transaction touched.
 	err = executor.Validate(st, tx)
 	if err != nil {
-		return nil, m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeInvalidTxnError, Message: fmt.Errorf("txn validation failed : %v", err)})
+		return m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeInvalidTxnError, Message: fmt.Errorf("txn validation failed : %v", err)})
 	}
 
 	// If we get here, we were successful in validating.  So, we need to
@@ -318,37 +362,35 @@ func (m *Executor) DeliverTx(tx *transactions.GenTransaction) (*protocol.TxResul
 	txAcceptedObject := new(state.Object)
 	txAcceptedObject.Entry, err = txAccepted.MarshalBinary()
 	if err != nil {
-		return nil, m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeMarshallingError, Message: err})
+		return m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeMarshallingError, Message: err})
 	}
 
 	txPendingObject := new(state.Object)
 	txPending.Status = json.RawMessage(fmt.Sprintf("{\"code\":\"0\"}"))
 	txPendingObject.Entry, err = txPending.MarshalBinary()
 	if err != nil {
-		return nil, m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeMarshallingError, Message: err})
+		return m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeMarshallingError, Message: err})
 	}
 
 	// Store the tx state
 	err = m.dbTx.AddTransaction(&chainId, tx.TransactionHash(), txPendingObject, txAcceptedObject)
 	if err != nil {
-		return nil, &protocol.Error{Code: protocol.CodeTxnStateError, Message: err}
+		return &protocol.Error{Code: protocol.CodeTxnStateError, Message: err}
 	}
 
 	// Store pending state updates, queue state creates for synthetic transactions
 	err = st.Commit()
 	if err != nil {
-		return nil, m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeRecordTxnError, Message: err})
+		return m.recordTransactionError(txPending, &chainId, tx.TransactionHash(), &protocol.Error{Code: protocol.CodeRecordTxnError, Message: err})
 	}
 
 	// Process synthetic transactions generated by the validator
-	refs, err := m.submitSyntheticTx(tx.TransactionHash(), st)
+	err = m.addSynthTxns(tx.TransactionHash(), st)
 	if err != nil {
-		return nil, &protocol.Error{Code: protocol.CodeSyntheticTxnError, Message: err}
+		return &protocol.Error{Code: protocol.CodeSyntheticTxnError, Message: err}
 	}
 
-	r := new(protocol.TxResult)
-	r.SyntheticTxs = refs
-	return r, nil
+	return nil
 }
 
 // EndBlock implements ./abci.Chain
@@ -360,34 +402,16 @@ func (m *Executor) Commit() ([]byte, error) {
 
 	mdRoot, err := m.dbTx.Commit(m.height, m.time)
 	if err != nil {
-		// This should never happen
-		panic(fmt.Errorf("fatal error, block not set, %v", err))
+		return nil, err
 	}
-
-	// // If we have no transactions this block then don't publish anything
-	// if m.leader && numStateChanges > 0 {
-	// 	// Now we create a synthetic transaction and publish to the directory
-	// 	// block validator
-	// 	dbvc := DeliverTxResult{}
-	// 	dbvc.SyntheticTransactions = make([]*transactions.GenTransaction, 1)
-	// 	dbvc.SyntheticTransactions[0] = &transactions.GenTransaction{}
-	// 	dcAdi := "dc"
-	// 	dbvc.SyntheticTransactions[0].ChainID = types.GetChainIdFromChainPath(&dcAdi).Bytes()
-	// 	dbvc.SyntheticTransactions[0].Routing = types.GetAddressFromIdentity(&dcAdi)
-	// 	//dbvc.Submissions[0].Transaction = ...
-
-	// 	//broadcast the root
-	// 	//m.processValidatedSubmissionRequest(&dbvc)
-	// }
-
-	m.query.BatchSend()
 
 	m.logger.Info("Committed", "db_time", m.db.TimeBucket)
 	m.db.TimeBucket = 0
 	return mdRoot, nil
 }
 
-func (m *Executor) nextSynthCount() (uint64, error) {
+// synthCount returns the number of synthetic transactions sent by this subnet.
+func (m *Executor) synthCount() (uint64, error) {
 	k := storage.ComputeKey("SyntheticTransactionCount")
 	b, err := m.dbTx.Read(k)
 	if err != nil && !errors.Is(err, storage.ErrNotFound) {
@@ -398,26 +422,39 @@ func (m *Executor) nextSynthCount() (uint64, error) {
 	if len(b) > 0 {
 		n, _ = common.BytesUint64(b)
 	}
+	return n, nil
+}
+
+// nextSynthCount returns and increments the number of synthetic transactions
+// sent by this subnet.
+func (m *Executor) nextSynthCount() (uint64, error) {
+	// TODO Replace this with the actual key nonce
+
+	n, err := m.synthCount()
+	if err != nil {
+		return 0, err
+	}
+
+	k := storage.ComputeKey("SyntheticTransactionCount")
 	m.dbTx.Write(k, common.Uint64Bytes(n+1))
 	return n, nil
 }
 
-func (m *Executor) submitSyntheticTx(parentTxId types.Bytes, st *StateManager) (tmRef []*protocol.TxSynthRef, err error) {
-	if m.leader {
-		tmRef = make([]*protocol.TxSynthRef, len(st.submissions))
-	}
-
+// addSynthTxns prepares synthetic transactions for signing next block.
+func (m *Executor) addSynthTxns(parentTxId types.Bytes, st *StateManager) error {
 	// Need to pass this to a threaded batcher / dispatcher to do both signing
 	// and sending of synth tx. No need to spend valuable time here doing that.
-	for i, sub := range st.submissions {
+	for _, sub := range st.submissions {
 		// Generate a synthetic tx and send to the router. Need to track txid to
 		// make sure they get processed.
 
+		// Marshal the payload
 		body, err := sub.body.MarshalBinary()
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal synthetic transaction payload: %v", err)
+			return fmt.Errorf("failed to marshal synthetic transaction payload: %v", err)
 		}
 
+		// Build the transaction
 		tx := new(transactions.GenTransaction)
 		tx.SigInfo = new(transactions.SignatureInfo)
 		tx.SigInfo.URL = sub.url.String()
@@ -425,11 +462,10 @@ func (m *Executor) submitSyntheticTx(parentTxId types.Bytes, st *StateManager) (
 		tx.SigInfo.PriorityIdx = 0
 		tx.Transaction = body
 
-		// TODO Populate nonce with something better
-		tx.SigInfo.MSHeight = uint64(m.height)
+		tx.SigInfo.MSHeight = 1
 		tx.SigInfo.Nonce, err = m.nextSynthCount()
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// Create the state object to store the unsigned pending transaction
@@ -437,48 +473,168 @@ func (m *Executor) submitSyntheticTx(parentTxId types.Bytes, st *StateManager) (
 		txSyntheticObject := new(state.Object)
 		synthTxData, err := txSynthetic.MarshalBinary()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		txSyntheticObject.Entry = synthTxData
 		m.dbTx.AddSynthTx(parentTxId, tx.TransactionHash(), txSyntheticObject)
-
-		// TODO In order for other BVCs to be able to validate the synthetic
-		// transaction, a wrapped signed version must be resubmitted to this BVC network
-		// and the UNSIGNED version of the transaction along with the Leader address will
-		// be stored in a SynthChain in the SMT on this BVC.  The BVC's will validate
-		// the synth transaction against the receipt and EVERYONE will then send out the wrapped
-		// TX along with the proof from the directory chain. If by end block there are still
-		// unprocessed synthetic TX's the current leader takes over, invalidates the previous
-		// leader's signed tx, signs the unprocessed synth tx, and tries again with the
-		// new leader.  By EVERYONE submitting the leader signed synth tx to the designated
-		// BVC network it takes advantage of the flood-fill gossip network tendermint will
-		// provide and ensure the synth transaction will be picked up.
-
-		// Batch synthetic transactions generated by the validator
-		if m.leader {
-			ed := new(transactions.ED25519Sig)
-			//only if a leader we will need to sign and batch the tx's.
-			//in future releases this will be submitted to this BVC to the next block for validation
-			//of the synthetic tx by all the bvc nodes before being dispatched, along with DC receipt
-			ed.PublicKey = m.key[32:]
-			err := ed.Sign(tx.SigInfo.Nonce, m.key, tx.TransactionHash())
-			if err != nil {
-				return nil, fmt.Errorf("error signing sythetic transaction, %v", err)
-			}
-
-			tx.Signature = append(tx.Signature, ed)
-			ti, err := m.query.BroadcastTx(tx, nil)
-			if err != nil {
-				return nil, err
-			}
-
-			tmRef[i] = new(protocol.TxSynthRef)
-			tmRef[i].Type = uint64(tx.TransactionType())
-			tmRef[i].Url = tx.SigInfo.URL
-			copy(tmRef[i].Hash[:], tx.TransactionHash())
-			copy(tmRef[i].TxRef[:], ti.ReferenceId)
-		}
 	}
 
-	return tmRef, nil
+	return nil
+}
+
+// signSynthTxns signs synthetic transactions from the previous block and
+// prepares them to be sent next block.
+func (m *Executor) signSynthTxns() error {
+	// TODO If the leader fails, will the block happen again or will Tendermint
+	// move to the next block? We need to be sure that synthetic transactions
+	// won't get lost.
+
+	// Get the anchor chain head
+	head, height, err := m.db.GetAnchorHead()
+	if errors.Is(err, storage.ErrNotFound) {
+		// Nothing to do
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// Only proceed if the previous block did something
+	if head.Index != m.height-1 {
+		return nil
+	}
+
+	// Only proceed if the previous block generated synthetic transactions
+	count := height - head.PreviousHeight - int64(len(head.Chains)) - 1
+	if count == 0 {
+		return nil
+	}
+
+	// Pull the transaction IDs from the anchor chain
+	txns, err := m.db.GetAnchors(height-count-1, height-1)
+	if err != nil {
+		return err
+	}
+
+	// Use the synthetic transaction count to calculate what the nonces were
+	nonce, err := m.synthCount()
+	if err != nil {
+		return err
+	}
+
+	// Sign all of the transactions
+	body := new(protocol.SyntheticSignTransactions)
+	for i, txid := range txns {
+		// For each pending synthetic transaction
+		var synthSig protocol.SyntheticSignature
+		synthSig.Txid = txid
+
+		// The nonce must be the final nonce minus (I + 1)
+		synthSig.Nonce = nonce - 1 - uint64(i)
+
+		// Sign it
+		ed := new(transactions.ED25519Sig)
+		ed.PublicKey = m.key[32:]
+		err = ed.Sign(synthSig.Nonce, m.key, txid[:])
+		if err != nil {
+			return err
+		}
+
+		// Add it to the list
+		synthSig.Signature = ed.Signature
+		body.Transactions = append(body.Transactions, synthSig)
+	}
+
+	// Construct the signature transaction
+	tx := new(transactions.GenTransaction)
+	tx.SigInfo = new(transactions.SignatureInfo)
+	tx.SigInfo.URL = protocol.ACME
+	tx.SigInfo.PriorityIdx = 0
+	tx.Transaction, err = body.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	tx.SigInfo.MSHeight = 1
+	tx.SigInfo.Nonce, err = m.nextSynthCount()
+	if err != nil {
+		return err
+	}
+
+	// Sign it
+	ed := new(transactions.ED25519Sig)
+	tx.Signature = append(tx.Signature, ed)
+	ed.PublicKey = m.key[32:]
+	err = ed.Sign(tx.SigInfo.Nonce, m.key, tx.TransactionHash())
+	if err != nil {
+		return err
+	}
+
+	// Marshal it
+	data, err := tx.Marshal()
+	if err != nil {
+		return err
+	}
+
+	// Send it
+	go m.local.BroadcastTxAsync(context.Background(), data)
+	return nil
+}
+
+// sendSynthTxns sends signed synthetic transactions from previous blocks.
+func (m *Executor) sendSynthTxns() ([]abci.SynthTxnReference, error) {
+	// Get the signatures from the last block
+	sigs, err := m.db.GetSynthTxnSigs()
+	if err != nil {
+		return nil, err
+	}
+
+	// Array for synth TXN references
+	refs := make([]abci.SynthTxnReference, 0, len(sigs))
+
+	// Process all the transactions
+	for _, sig := range sigs {
+		// Load the pending transaction object
+		obj, err := m.db.GetSynthTxn(sig.Txid)
+		if err != nil {
+			return nil, err
+		}
+
+		// Unmarshal it
+		state := new(state.PendingTransaction)
+		err = obj.As(state)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert it back to a transaction
+		tx := state.Restore()
+
+		// Add the signature
+		tx.Signature = append(tx.Signature, &transactions.ED25519Sig{
+			Nonce:     sig.Nonce,
+			PublicKey: sig.PublicKey,
+			Signature: sig.Signature,
+		})
+
+		// Add it to the batch
+		ti, err := m.query.BroadcastTx(tx, nil)
+		if err != nil {
+			continue
+		}
+
+		// Delete the signature
+		m.dbTx.DeleteSynthTxnSig(sig.Txid)
+
+		// Add the synthetic transaction reference
+		var ref abci.SynthTxnReference
+		ref.Type = uint64(tx.TransactionType())
+		ref.Url = tx.SigInfo.URL
+		copy(ref.Hash[:], tx.TransactionHash())
+		copy(ref.TxRef[:], ti.ReferenceId)
+		refs = append(refs, ref)
+	}
+
+	// Send the batches
+	m.query.BatchSend()
+
+	return refs, nil
 }

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -25,6 +25,7 @@ type StateManager struct {
 	storeCount  int
 	txHash      types.Bytes32
 	txType      types.TxType
+	synthSigs   []*state.SyntheticSignature
 
 	Sponsor        state.Chain
 	SponsorUrl     *url.URL
@@ -299,6 +300,10 @@ func (m *StateManager) Commit() error {
 		}
 	}
 
+	for _, sig := range m.synthSigs {
+		m.dbTx.AddSynthTxnSig(sig)
+	}
+
 	return nil
 }
 
@@ -311,7 +316,8 @@ func unmarshalRecord(obj *state.Object) (state.Chain, error) {
 
 	var record state.Chain
 	switch header.Type {
-	// TODO DC, BVC, Token
+	case types.ChainTypeTokenIssuer:
+		record = new(protocol.TokenIssuer)
 	case types.ChainTypeIdentity:
 		record = new(state.AdiState)
 	case types.ChainTypeTokenAccount:
@@ -382,4 +388,31 @@ func AddDirectoryEntry(db interface {
 	db.WriteIndex(state.DirectoryIndex, idc, "Metadata", b)
 	db.WriteIndex(state.DirectoryIndex, idc, c, []byte(u.String()))
 	return nil
+}
+
+// LoadSynthTxn loads and unmarshals a saved synthetic transaction
+func (m *StateManager) LoadSynthTxn(txid [32]byte) (*state.PendingTransaction, error) {
+	obj, err := m.dbTx.DB().GetSynthTxn(txid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get txn %X: %v", txid, err)
+	}
+
+	state := new(state.PendingTransaction)
+	err = obj.As(state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal txn %X: %v", txid, err)
+	}
+
+	return state, nil
+}
+
+// AddSynthTxnSig adds a synthetic transaction signature to the list of
+// synthetic transactions that should be sent next block.
+func (m *StateManager) AddSynthTxnSig(publicKey []byte, sig *protocol.SyntheticSignature) {
+	m.synthSigs = append(m.synthSigs, &state.SyntheticSignature{
+		Txid:      sig.Txid,
+		Signature: sig.Signature,
+		PublicKey: publicKey,
+		Nonce:     sig.Nonce,
+	})
 }

--- a/internal/chain/synthetic_sign_transactions.go
+++ b/internal/chain/synthetic_sign_transactions.go
@@ -1,0 +1,50 @@
+package chain
+
+import (
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type SyntheticSignTransactions struct{}
+
+func (SyntheticSignTransactions) Type() types.TxType { return types.TxTypeSyntheticSignTransactions }
+
+func (SyntheticSignTransactions) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.SyntheticSignTransactions)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	// Process the signatures
+	for _, entry := range body.Transactions {
+		// Load the pending transaction state
+		state, err := st.LoadSynthTxn(entry.Txid)
+		if err != nil {
+			return err
+		}
+
+		// Convert it into a transaction
+		synTxn := state.Restore()
+
+		// Add the signature
+		synTxn.Signature = append(synTxn.Signature, &transactions.ED25519Sig{
+			Nonce:     entry.Nonce,
+			Signature: entry.Signature,
+			PublicKey: tx.Signature[0].PublicKey,
+		})
+
+		// Validate it
+		if !synTxn.ValidateSig() {
+			return fmt.Errorf("invalid signature for txn %X", entry.Txid)
+		}
+
+		// Queue the transaction for sending next block
+		st.AddSynthTxnSig(tx.Signature[0].PublicKey, &entry)
+	}
+
+	return nil
+}

--- a/internal/mock/abci/abci.go
+++ b/internal/mock/abci/abci.go
@@ -38,9 +38,12 @@ func (m *MockChain) EXPECT() *MockChainMockRecorder {
 }
 
 // BeginBlock mocks base method.
-func (m *MockChain) BeginBlock(arg0 abci.BeginBlockRequest) {
+func (m *MockChain) BeginBlock(arg0 abci.BeginBlockRequest) (abci.BeginBlockResponse, error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "BeginBlock", arg0)
+	ret := m.ctrl.Call(m, "BeginBlock", arg0)
+	ret0, _ := ret[0].(abci.BeginBlockResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // BeginBlock indicates an expected call of BeginBlock.
@@ -79,12 +82,11 @@ func (mr *MockChainMockRecorder) Commit() *gomock.Call {
 }
 
 // DeliverTx mocks base method.
-func (m *MockChain) DeliverTx(arg0 *transactions.GenTransaction) (*protocol.TxResult, *protocol.Error) {
+func (m *MockChain) DeliverTx(arg0 *transactions.GenTransaction) *protocol.Error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliverTx", arg0)
-	ret0, _ := ret[0].(*protocol.TxResult)
-	ret1, _ := ret[1].(*protocol.Error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*protocol.Error)
+	return ret0
 }
 
 // DeliverTx indicates an expected call of DeliverTx.

--- a/internal/node/local_client.go
+++ b/internal/node/local_client.go
@@ -1,0 +1,74 @@
+package node
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tendermint/tendermint/libs/bytes"
+	"github.com/tendermint/tendermint/rpc/client/local"
+	core "github.com/tendermint/tendermint/rpc/core/types"
+	tm "github.com/tendermint/tendermint/types"
+)
+
+var ErrNotInitialized = errors.New("not initialized")
+
+// LocalClient is a proxy for local.Local that is used when a local client is
+// needed before the node has been started.
+type LocalClient struct {
+	client *local.Local
+	queue  []tm.Tx
+}
+
+// NewLocalClient creates a new LocalClient.
+func NewLocalClient() *LocalClient {
+	c := new(LocalClient)
+	return c
+}
+
+// Set sets the local.Local client, transmitting any queued transactions.
+func (c *LocalClient) Set(client *local.Local) {
+	c.client = client
+	queue := c.queue
+	c.queue = nil
+	for _, tx := range queue {
+		_, _ = client.BroadcastTxAsync(context.Background(), tx)
+	}
+}
+
+// ABCIQuery implements client.ABCIClient.ABCIQuery. Returns ErrNotInitialized
+// if Set has not been called.
+func (c *LocalClient) ABCIQuery(ctx context.Context, path string, data bytes.HexBytes) (*core.ResultABCIQuery, error) {
+	if c.client == nil {
+		return nil, ErrNotInitialized
+	}
+	return c.client.ABCIQuery(ctx, path, data)
+}
+
+// CheckTx implements client.MempoolClient.CheckTx. Returns ErrNotInitialized if
+// Set has not been called.
+func (c *LocalClient) CheckTx(ctx context.Context, tx tm.Tx) (*core.ResultCheckTx, error) {
+	if c.client == nil {
+		return nil, ErrNotInitialized
+	}
+	return c.client.CheckTx(ctx, tx)
+}
+
+// BroadcastTxAsync implements client.ABCIClient.BroadcastTxAsync. If Set has
+// not been called, the transaction is queued and will be sent when Set is
+// called.
+func (c *LocalClient) BroadcastTxAsync(ctx context.Context, tx tm.Tx) (*core.ResultBroadcastTx, error) {
+	if c.client == nil {
+		c.queue = append(c.queue, tx)
+		return &core.ResultBroadcastTx{Hash: tx.Hash()}, nil
+	}
+	return c.client.BroadcastTxAsync(ctx, tx)
+}
+
+// BroadcastTxSync implements client.ABCIClient.BroadcastTxSync. Returns
+// ErrNotInitialized if Set has not been called.
+func (c *LocalClient) BroadcastTxSync(ctx context.Context, tx tm.Tx) (*core.ResultBroadcastTx, error) {
+	if c.client == nil {
+		return nil, ErrNotInitialized
+	}
+	return c.client.BroadcastTxSync(ctx, tx)
+}

--- a/internal/node/utils_test.go
+++ b/internal/node/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/AccumulateNetwork/accumulate/config"
 	cfg "github.com/AccumulateNetwork/accumulate/config"
@@ -69,6 +70,9 @@ func initNodes(t *testing.T, name string, baseIP net.IP, basePort int, count int
 		c.Instrumentation.Prometheus = false
 		c.Accumulate.WebsiteEnabled = false
 		c.LogLevel = logLevel
+
+		// Make a block every 1/10th second, to make tests go faster
+		c.Consensus.TimeoutCommit = time.Second / 10
 
 		require.NoError(t, cfg.Store(c))
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -213,7 +213,7 @@ func (r *Relay) BatchSend() <-chan BatchedStatus {
 		//reset the queue here.
 		r.txQueue[i] = txBatch{}
 	}
-	stat := make(chan BatchedStatus)
+	stat := make(chan BatchedStatus, 1)
 	go dispatch(r.client, sendTxsAsBatch, sendTxsAsSingle, stat)
 	r.resetBatches()
 

--- a/internal/testing/app_client.go
+++ b/internal/testing/app_client.go
@@ -3,14 +3,15 @@ package testing
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/AccumulateNetwork/accumulate/internal/relay"
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
 	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulate/types/state"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/bytes"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
@@ -29,12 +30,19 @@ type ABCIApplicationClient struct {
 
 	appWg      *sync.WaitGroup
 	app        abci.Application
+	db         *state.StateDB
 	nextHeight func() int64
 	onError    func(err error)
 
+	done   chan struct{}
+	doneMu *sync.Mutex
+
 	txCh     chan *txStatus
 	txStatus map[[32]byte]*txStatus
+	txPend   map[[32]byte]bool
 	txMu     *sync.RWMutex
+	txCond   *sync.Cond
+	txActive int
 }
 
 type txStatus struct {
@@ -52,15 +60,20 @@ type txStatus struct {
 
 var _ relay.Client = (*ABCIApplicationClient)(nil)
 
-func NewABCIApplicationClient(app <-chan abci.Application, nextHeight func() int64, onError func(err error), interval time.Duration) *ABCIApplicationClient {
+func NewABCIApplicationClient(app <-chan abci.Application, db *state.StateDB, nextHeight func() int64, onError func(err error), interval time.Duration) *ABCIApplicationClient {
 	c := new(ABCIApplicationClient)
 	c.appWg = new(sync.WaitGroup)
+	c.db = db
 	c.nextHeight = nextHeight
 	c.onError = onError
 	c.EventBus = types.NewEventBus()
+	c.done = make(chan struct{})
+	c.doneMu = new(sync.Mutex)
 	c.txCh = make(chan *txStatus)
 	c.txStatus = map[[32]byte]*txStatus{}
+	c.txPend = map[[32]byte]bool{}
 	c.txMu = new(sync.RWMutex)
+	c.txCond = sync.NewCond(c.txMu.RLocker())
 
 	c.appWg.Add(1)
 	go func() {
@@ -73,7 +86,17 @@ func NewABCIApplicationClient(app <-chan abci.Application, nextHeight func() int
 }
 
 func (c *ABCIApplicationClient) Shutdown() {
+	c.doneMu.Lock()
+	defer c.doneMu.Unlock()
+
+	select {
+	case <-c.done:
+		return
+	default:
+	}
+
 	close(c.txCh)
+	<-c.done
 }
 
 func (c *ABCIApplicationClient) App() abci.Application {
@@ -83,20 +106,13 @@ func (c *ABCIApplicationClient) App() abci.Application {
 
 // Wait until all pending transactions are done
 func (c *ABCIApplicationClient) Wait() {
-	c.txMu.RLock()
-	ch := make([]chan struct{}, 0, len(c.txStatus))
-	for _, st := range c.txStatus {
-		if !st.Done {
-			ch = append(ch, st.DidCommit)
-		}
-	}
-	c.txMu.RUnlock()
-
 	if debugTX {
-		fmt.Printf("Waiting for %d transactions\n", len(ch))
+		fmt.Printf("Waiting for transactions\n")
 	}
-	for _, ch := range ch {
-		<-ch
+	c.txMu.RLock()
+	defer c.txMu.RUnlock()
+	for c.txActive > 0 || len(c.txPend) > 0 {
+		c.txCond.Wait()
 	}
 	if debugTX {
 		fmt.Printf("Done waiting\n")
@@ -105,11 +121,8 @@ func (c *ABCIApplicationClient) Wait() {
 
 func (c *ABCIApplicationClient) SubmitTx(ctx context.Context, tx types.Tx) *txStatus {
 	st := c.didSubmit(tx, sha256.Sum256(tx))
-
-	if debugTX {
-		gtx := new(transactions.GenTransaction)
-		_, _ = gtx.UnMarshal(st.Tx)
-		fmt.Printf("Submitting %v %X\n", gtx.TransactionType(), st.Hash)
+	if st == nil {
+		return nil
 	}
 
 	c.txCh <- st
@@ -117,39 +130,85 @@ func (c *ABCIApplicationClient) SubmitTx(ctx context.Context, tx types.Tx) *txSt
 }
 
 func (c *ABCIApplicationClient) didSubmit(tx []byte, txh [32]byte) *txStatus {
-	c.txMu.Lock()
-	st, ok := c.txStatus[txh]
-	if !ok {
-		st = new(txStatus)
-		c.txStatus[txh] = st
-		st.Tx = tx
-		st.Hash = txh
-		st.DidCheck = make(chan struct{})
-		st.DidDeliver = make(chan struct{})
-		st.DidCommit = make(chan struct{})
+	gtx := new(transactions.GenTransaction)
+	_, err := gtx.UnMarshal(tx)
+	if err != nil {
+		c.onError(err)
+		if debugTX {
+			fmt.Printf("Rejecting invalid transaction: %v\n", err)
+		}
+		return nil
 	}
-	c.txMu.Unlock()
 
-	if !ok {
+	if debugTX {
+		txt := gtx.TransactionType()
+		fmt.Printf("Submitting %v %X\n", txt, txh)
+	}
+
+	var txid [32]byte
+	copy(txid[:], gtx.TransactionHash())
+
+	c.txMu.Lock()
+	defer c.txMu.Unlock()
+
+	delete(c.txPend, txid)
+
+	st, ok := c.txStatus[txh]
+	if ok {
+		// Ignore duplicate transactions
 		return st
 	}
 
-	if st.Done {
-		panic("Duplicate TX!")
-	}
-
-	// Synthetic transaction entries are added with a blank TX
-	if st.Tx == nil && tx != nil {
-		st.Tx = tx
-	}
-
-	// Ignore duplicate transactions I guess
+	st = new(txStatus)
+	c.txStatus[txh] = st
+	st.Tx = tx
+	st.Hash = txh
+	st.DidCheck = make(chan struct{})
+	st.DidDeliver = make(chan struct{})
+	st.DidCommit = make(chan struct{})
+	c.txActive++
 	return st
+}
+
+func (c *ABCIApplicationClient) addSynthTxns() {
+	// Check for synthetic transactions in the anchor chain
+	head, height, err := c.db.GetAnchorHead()
+	if errors.Is(err, storage.ErrNotFound) {
+		return
+	} else if err != nil {
+		c.onError(err)
+		return
+	}
+
+	count := height - head.PreviousHeight - int64(len(head.Chains)) - 1
+	if count == 0 {
+		return
+	}
+
+	if debugTX {
+		fmt.Printf("The last block created %d synthetic transactions\n", count)
+	}
+
+	// Pull the transaction IDs from the anchor chain
+	txns, err := c.db.GetAnchors(height-count-1, height-1)
+	if err != nil {
+		c.onError(err)
+		return
+	}
+
+	c.txMu.Lock()
+	defer c.txMu.Unlock()
+	for _, h := range txns {
+		c.txPend[h] = true
+	}
 }
 
 // execute accepts incoming transactions and queues them up for the next block
 func (c *ABCIApplicationClient) execute(interval time.Duration) {
+	defer close(c.done)
+
 	var queue []*txStatus
+	var hadTxnLastTime bool
 	tick := time.NewTicker(interval)
 
 	for {
@@ -174,7 +233,7 @@ func (c *ABCIApplicationClient) execute(interval time.Duration) {
 			continue
 
 		case <-tick.C:
-			if len(queue) == 0 && !c.CreateEmptyBlocks {
+			if len(queue) == 0 && !c.CreateEmptyBlocks && !hadTxnLastTime {
 				continue
 			}
 			if c.app == nil {
@@ -192,12 +251,16 @@ func (c *ABCIApplicationClient) execute(interval time.Duration) {
 			// Done
 		}
 
+		height := c.nextHeight()
+		if debugTX {
+			fmt.Printf("Beginning block %d with %d transactions queued\n", height, len(queue))
+		}
+
 		begin := abci.RequestBeginBlock{}
-		begin.Header.Height = c.nextHeight()
+		begin.Header.Height = height
 		c.app.BeginBlock(begin)
 
 		// Process the queue
-		var synth [][32]byte
 		for _, sub := range queue {
 			// TODO Index
 			sub.Height = begin.Header.Height
@@ -222,27 +285,6 @@ func (c *ABCIApplicationClient) execute(interval time.Duration) {
 			}
 			if dr.Code != 0 {
 				c.onError(fmt.Errorf("DeliverTx failed: %v\n", dr.Log))
-			} else {
-				for _, e := range dr.Events {
-					if e.Type != "accSyn" {
-						continue
-					}
-
-					for _, a := range e.Attributes {
-						if a.Key != "txRef" {
-							continue
-						}
-
-						b, err := hex.DecodeString(a.Value)
-						if err != nil || len(b) != 32 {
-							continue
-						}
-
-						var h [32]byte
-						copy(h[:], b)
-						synth = append(synth, h)
-					}
-				}
 			}
 
 			err := c.PublishEventTx(types.EventDataTx{TxResult: abci.TxResult{
@@ -259,14 +301,6 @@ func (c *ABCIApplicationClient) execute(interval time.Duration) {
 		c.app.EndBlock(abci.RequestEndBlock{})
 		c.app.Commit()
 
-		// Ensure Wait waits for synthetic transactions
-		for _, h := range synth {
-			if debugTX {
-				fmt.Printf("Synthetic %X\n", h)
-			}
-			c.didSubmit(nil, h)
-		}
-
 		for _, sub := range queue {
 			close(sub.DidCommit)
 			sub.Done = true
@@ -275,8 +309,21 @@ func (c *ABCIApplicationClient) execute(interval time.Duration) {
 			}
 		}
 
+		// Ensure Wait waits for synthetic transactions
+		c.addSynthTxns()
+
+		c.txActive -= len(queue)
+		c.txCond.Broadcast()
+
+		// Remember if this block had transactions
+		hadTxnLastTime = len(queue) > 0
+
 		// Clear the queue (reuse the memory)
 		queue = queue[:0]
+
+		if debugTX {
+			fmt.Printf("Completed block %d with %d transactions pending\n", height, c.txActive+len(c.txPend))
+		}
 	}
 }
 
@@ -314,6 +361,11 @@ func (c *ABCIApplicationClient) ABCIQueryWithOptions(ctx context.Context, path s
 	return &ctypes.ResultABCIQuery{Response: r}, nil
 }
 
+func (c *ABCIApplicationClient) CheckTx(ctx context.Context, tx types.Tx) (*ctypes.ResultCheckTx, error) {
+	cr := c.App().CheckTx(abci.RequestCheckTx{Tx: tx})
+	return &ctypes.ResultCheckTx{ResponseCheckTx: cr}, nil
+}
+
 func (c *ABCIApplicationClient) BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
 	// Wait for nothing
 	c.SubmitTx(ctx, tx)
@@ -321,16 +373,21 @@ func (c *ABCIApplicationClient) BroadcastTxAsync(ctx context.Context, tx types.T
 }
 
 func (c *ABCIApplicationClient) BroadcastTxSync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error) {
-	// Wait for CheckTx
-	st := c.SubmitTx(ctx, tx)
-	<-st.DidCheck
+	cr := c.app.CheckTx(abci.RequestCheckTx{Tx: tx})
+	if cr.Code != 0 {
+		c.onError(fmt.Errorf("CheckTx failed: %v\n", cr.Log))
+	} else {
+		c.SubmitTx(ctx, tx)
+	}
+
+	hash := sha256.Sum256(tx)
 	return &ctypes.ResultBroadcastTx{
-		Code:         st.CheckResult.Code,
-		Data:         st.CheckResult.Data,
-		Log:          st.CheckResult.Log,
-		Codespace:    st.CheckResult.Codespace,
-		MempoolError: st.CheckResult.MempoolError,
-		Hash:         st.Hash[:],
+		Code:         cr.Code,
+		Data:         cr.Data,
+		Log:          cr.Log,
+		Codespace:    cr.Codespace,
+		MempoolError: cr.MempoolError,
+		Hash:         hash[:],
 	}, nil
 }
 

--- a/internal/testing/e2e/suite.go
+++ b/internal/testing/e2e/suite.go
@@ -3,31 +3,32 @@ package e2e
 import (
 	"crypto/ed25519"
 	"encoding"
-	"encoding/hex"
-	"os"
-	"strings"
 	"sync"
-	"time"
 
-	"github.com/AccumulateNetwork/accumulate/internal/api"
-	"github.com/AccumulateNetwork/accumulate/internal/relay"
 	"github.com/AccumulateNetwork/accumulate/internal/testing"
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	"github.com/AccumulateNetwork/accumulate/protocol"
 	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
 	"github.com/AccumulateNetwork/accumulate/types/state"
 	"github.com/stretchr/testify/suite"
-	abci "github.com/tendermint/tendermint/abci/types"
 	tmed25519 "github.com/tendermint/tendermint/crypto/ed25519"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"golang.org/x/exp/rand"
 )
 
-type StartNode func(*Suite) *api.Query
+type NewDUT func(*Suite) DUT
+
+// DUT are the parameters needed to test the Device Under Test.
+type DUT interface {
+	GetUrl(url string) (*ctypes.ResultABCIQuery, error)
+	SubmitTxn(*transactions.GenTransaction)
+	WaitForTxns()
+}
 
 type Suite struct {
 	suite.Suite
-	start StartNode
-	query *api.Query
+	start NewDUT
+	dut   DUT
 	rand  *rand.Rand
 
 	synthMu *sync.Mutex
@@ -36,14 +37,14 @@ type Suite struct {
 
 var _ suite.SetupTestSuite = (*Suite)(nil)
 
-func NewSuite(start StartNode) *Suite {
+func NewSuite(start NewDUT) *Suite {
 	s := new(Suite)
 	s.start = start
 	return s
 }
 
 func (s *Suite) SetupTest() {
-	s.query = s.start(s)
+	s.dut = s.start(s)
 	s.rand = rand.New(rand.NewSource(0))
 	s.synthMu = new(sync.Mutex)
 	s.synthTx = map[[32]byte]*url.URL{}
@@ -70,103 +71,13 @@ func (s *Suite) newTx(sponsor *url.URL, key tmed25519.PrivKey, nonce uint64, bod
 
 func (s *Suite) getChainAs(url string, obj encoding.BinaryUnmarshaler) {
 	s.T().Helper()
-	r, err := s.query.QueryByUrl(url)
+	r, err := s.dut.GetUrl(url)
 
 	s.Require().NoError(err)
 	s.Require().Zero(r.Response.Code, "Query failed: %v", r.Response.Info)
 	so := state.Object{}
 	s.Require().NoError(so.UnmarshalBinary(r.Response.Value))
 	s.Require().NoError(obj.UnmarshalBinary(so.Entry))
-}
-
-func (s *Suite) sendTxAsync(tx *transactions.GenTransaction) func(relay.BatchedStatus) {
-	done := make(chan abci.TxResult, 1)
-	ti, err := s.query.BroadcastTx(tx, done)
-	s.Require().NoError(err)
-
-	return func(bs relay.BatchedStatus) {
-		r, err := bs.ResolveTransactionResponse(ti)
-		s.Require().NoError(err)
-		s.Require().Zero(r.Code, "TX failed: %s", r.Log)
-		s.Require().Empty(r.MempoolError, "TX failed: %s", r.MempoolError)
-
-		var timer *time.Timer
-		if os.Getenv("CI") == "true" {
-			timer = time.NewTimer(15 * time.Minute)
-		} else {
-			timer = time.NewTimer(1 * time.Minute)
-		}
-		defer timer.Stop()
-
-		var txr abci.TxResult
-		select {
-		case txr = <-done:
-			s.Require().Zerof(txr.Result.Code, "TX failed: %s", txr.Result.Log)
-		case <-timer.C:
-			s.T().Fatal("Timed out while waiting for TX repsonse")
-		}
-
-		for _, e := range txr.Result.Events {
-			if e.Type != "accSyn" {
-				continue
-			}
-
-			var id [32]byte
-			var u *url.URL
-			for _, a := range e.Attributes {
-				switch a.Key {
-				case "txRef":
-					b, err := hex.DecodeString(a.Value)
-					if s.NoError(err) {
-						copy(id[:], b)
-					}
-				case "url":
-					u, err = url.Parse(a.Value)
-					s.NoError(err)
-				}
-			}
-
-			if id != ([32]byte{}) && u != nil {
-				s.synthMu.Lock()
-				s.synthTx[id] = u
-				s.synthMu.Unlock()
-			}
-		}
-	}
-}
-
-func (s *Suite) waitForSynth() {
-	s.T().Helper()
-	for {
-		s.synthMu.Lock()
-		if len(s.synthTx) == 0 {
-			s.synthMu.Unlock()
-			return
-		}
-
-		var id [32]byte
-		var u *url.URL
-		for id, u = range s.synthTx {
-		}
-		delete(s.synthTx, id)
-		s.synthMu.Unlock()
-
-		// Poll for TX results. This is hacky, but it's a test.
-		for {
-			r, err := s.query.GetTx(u.Routing(), id)
-			if err == nil {
-				s.Require().Zero(r.TxResult.Code, "TX failed: %s", r.TxResult.Log)
-				break
-			}
-
-			if !strings.Contains(err.Error(), "not found") {
-				s.Require().NoError(err)
-				break
-			}
-
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
 }
 
 func (s *Suite) parseUrl(str string) *url.URL {
@@ -184,8 +95,8 @@ func (s *Suite) anonUrl(key tmed25519.PrivKey) *url.URL {
 func (s *Suite) deposit(sponsor, recipient tmed25519.PrivKey) {
 	tx, err := testing.CreateFakeSyntheticDepositTx(sponsor, recipient)
 	s.Require().NoError(err)
-	s.sendTxAsync(tx)(<-s.query.BatchSend())
-	// Does not generate synthetic transactions
+	s.dut.SubmitTxn(tx)
+	s.dut.WaitForTxns()
 }
 
 func (s *Suite) createADI(sponsor *url.URL, sponsorKey tmed25519.PrivKey, nonce uint64, adi string, adiKey tmed25519.PrivKey) {
@@ -196,5 +107,6 @@ func (s *Suite) createADI(sponsor *url.URL, sponsorKey tmed25519.PrivKey, nonce 
 	ic.KeyPageName = "key0-0"
 
 	tx := s.newTx(sponsor, sponsorKey, nonce, ic)
-	s.sendTxAsync(tx)(<-s.query.BatchSend())
+	s.dut.SubmitTxn(tx)
+	s.dut.WaitForTxns()
 }

--- a/internal/testing/state.go
+++ b/internal/testing/state.go
@@ -63,7 +63,6 @@ func CreateFakeSyntheticDepositTx(sponsor, recipient ed25519.PrivKey) (*transact
 
 func CreateAnonTokenAccount(db DB, key ed25519.PrivKey, tokens float64) error {
 	url := types.String(anon.GenerateAcmeAddress(key.PubKey().Bytes()))
-	fmt.Println(url)
 	return CreateTokenAccount(db, string(url), protocol.AcmeUrl().String(), tokens, true)
 }
 

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -12,27 +12,6 @@
 # Duration is marshalled as two uvarints: seconds and nanoseconds. A duration of
 # 1 hour and 1 ns is marshalled as (3600, 1).
 
-TxResult:
-  fields:
-    - name: SyntheticTxs
-      type: slice
-      slice:
-        type: TxSynthRef
-        pointer: true
-        marshal-as: self
-
-TxSynthRef:
-  fields:
-    - name: Type
-      type: uvarint
-    - name: Hash
-      type: chain
-    - name: Url
-      type: string
-      is-url: true
-    - name: TxRef # The hash of the transaction blob submitted to Tendermint. Use to look up the transaction status.
-      type: chain
-
 AnonTokenAccount:
   kind: chain
   chain-type: LiteTokenAccount
@@ -301,3 +280,21 @@ TokenIssuer:
     - name: Properties
       type: string
       is-url: true
+
+SyntheticSignTransactions:
+  kind: tx
+  fields:
+    - name: Transactions
+      type: slice
+      slice:
+        type: SyntheticSignature
+        marshal-as: self
+
+SyntheticSignature:
+  fields:
+    - name: Txid
+      type: chain
+    - name: Signature
+      type: bytes
+    - name: Nonce
+      type: uvarint

--- a/types/api/transactions/SignatureInfo.go
+++ b/types/api/transactions/SignatureInfo.go
@@ -61,8 +61,8 @@ func (t *SignatureInfo) Equal(t2 *SignatureInfo) bool {
 // Create the binary representation of the GenTransaction
 func (t *SignatureInfo) Marshal() (data []byte, err error) { //            Serialize the Signature Info
 	defer func() { //                                                      If any problems are encountered, then
-		if err := recover(); err != nil { //                               Complain
-			err = fmt.Errorf("error marshaling GenTransaction %v", err) //
+		if r := recover(); r != nil { //                               Complain
+			err = fmt.Errorf("error marshaling GenTransaction %v", r) //
 		} //
 	}()
 
@@ -79,8 +79,8 @@ func (t *SignatureInfo) Marshal() (data []byte, err error) { //            Seria
 // the GenTransaction
 func (t *SignatureInfo) UnMarshal(data []byte) (nextData []byte, err error) { // Get the data from the input stream
 	defer func() { //                                                            and set the values.  Any problem
-		if err := recover(); err != nil { //                                     will be reported
-			err = fmt.Errorf("error unmarshaling GenTransaction %v", err) //
+		if r := recover(); r != nil { //                                     will be reported
+			err = fmt.Errorf("error unmarshaling GenTransaction %v", r) //
 		} //
 	}() //
 

--- a/types/api/transactions/ed25519sig.go
+++ b/types/api/transactions/ed25519sig.go
@@ -92,8 +92,8 @@ func (e *ED25519Sig) Verify(hash []byte) bool {
 func (e *ED25519Sig) Marshal() (data []byte, err error) { //
 
 	defer func() { //                                                   On any error, just report the error
-		if err := recover(); err != nil { //                            Check for error on exist
-			err = fmt.Errorf("error marshaling ED25519Sig %v", err) //  Generate the error message
+		if r := recover(); r != nil { //                            Check for error on exist
+			err = fmt.Errorf("error marshaling ED25519Sig %v", r) //  Generate the error message
 		} //
 	}() //                                                              If no error occurs, err will be nil
 

--- a/types/state/StateDB.go
+++ b/types/state/StateDB.go
@@ -30,14 +30,14 @@ type transactionStateInfo struct {
 type transactionLists struct {
 	validatedTx []*transactionStateInfo //list of validated transaction chain state objects for block
 	pendingTx   []*transactionStateInfo //list of pending transaction chain state objects for block
-	synthTxMap  map[types.Bytes32]*[]transactionStateInfo
+	synthTxMap  map[types.Bytes32][]transactionStateInfo
 }
 
 // reset will (re)initialize the transaction lists, this should be done on startup and at the end of each block
 func (t *transactionLists) reset() {
 	t.pendingTx = nil
 	t.validatedTx = nil
-	t.synthTxMap = make(map[types.Bytes32]*[]transactionStateInfo)
+	t.synthTxMap = make(map[types.Bytes32][]transactionStateInfo)
 }
 
 type bucket string
@@ -50,6 +50,7 @@ const (
 	bucketStagedSynthTx    = bucket("StagedSynthTx") //store the staged synthetic transactions
 	bucketTxToSynthTx      = bucket("TxToSynthTx")   //TXID to synthetic TXID
 	bucketMinorAnchorChain = bucket("MinorAnchorChain")
+	bucketSynthTxnSigs     = bucket("SyntheticTransactionSignatures")
 
 	markPower = int64(8)
 )
@@ -154,6 +155,8 @@ func (s *StateDB) GetChainRange(chainId []byte, start int64, end int64) (hashes 
 		end = s.mm.MS.Count
 	}
 
+	// GetRange will not cross mark point boundaries, so we may need to call it
+	// multiple times
 	hashes = make([]types.Bytes32, 0, end-start)
 	for start < end {
 		h, err := s.mm.GetRange(chainId, start, end)
@@ -167,7 +170,7 @@ func (s *StateDB) GetChainRange(chainId []byte, start int64, end int64) (hashes 
 		start += int64(len(h))
 	}
 
-	return hashes, s.mm.GetElementCount(), nil
+	return hashes, s.mm.MS.Count, nil
 }
 
 //GetTx get the transaction by transaction ID
@@ -211,15 +214,11 @@ func (s *StateDB) GetSyntheticTxIds(txId []byte) (syntheticTxIds []byte, err err
 //AddSynthTx add the synthetic transaction which is mapped to the parent transaction
 func (tx *DBTransaction) AddSynthTx(parentTxId types.Bytes, synthTxId types.Bytes, synthTxObject *Object) {
 	tx.state.logInfo("AddSynthTx", "txid", logging.AsHex(synthTxId), "entry", logging.AsHex(synthTxObject.Entry))
-	var val *[]transactionStateInfo
-	var ok bool
+	tx.dirty = true
 
 	parentHash := parentTxId.AsBytes32()
-	if val, ok = tx.transactions.synthTxMap[parentHash]; !ok {
-		val = new([]transactionStateInfo)
-		tx.transactions.synthTxMap[parentHash] = val
-	}
-	*val = append(*val, transactionStateInfo{synthTxObject, nil, synthTxId})
+	m := tx.transactions.synthTxMap
+	m[parentHash] = append(m[parentHash], transactionStateInfo{synthTxObject, nil, synthTxId})
 }
 
 // AddTransaction queues (pending) transaction signatures and (optionally) an
@@ -230,6 +229,7 @@ func (tx *DBTransaction) AddTransaction(chainId *types.Bytes32, txId types.Bytes
 		txAcceptedEntry = txAccepted.Entry
 	}
 	tx.state.logInfo("AddTransaction", "chainId", logging.AsHex(chainId), "txid", logging.AsHex(txId), "pending", logging.AsHex(txPending.Entry), "accepted", logging.AsHex(txAcceptedEntry))
+	tx.dirty = true
 
 	chainType, _ := binary.Uvarint(txPending.Entry)
 	if types.ChainType(chainType) != types.ChainTypePendingTransaction {
@@ -287,15 +287,42 @@ func (s *StateDB) GetPersistentEntry(chainId []byte, verify bool) (*Object, erro
 	return ret, nil
 }
 
-// GetTransaction loads the state of the given transaction.
-func (s *StateDB) GetTransaction(txid []byte) (*Object, error) {
+func (s *StateDB) getObject(keys ...interface{}) (*Object, error) {
 	s.Sync()
 
 	if s.db == nil {
 		return nil, fmt.Errorf("database has not been initialized")
 	}
 
-	data, err := s.db.Key(bucketTx, txid).Get()
+	data, err := s.db.Key(keys...).Get()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &Object{}
+	err = ret.UnmarshalBinary(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal: %v", err)
+	}
+
+	return ret, nil
+}
+
+// GetTransaction loads the state of the given transaction.
+func (s *StateDB) GetTransaction(txid []byte) (*Object, error) {
+	obj, err := s.getObject(bucketTx, txid)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, fmt.Errorf("%w: no transaction defined for %X", storage.ErrNotFound, txid)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transaction %X: %v", txid, err)
+	}
+	return obj, nil
+}
+
+// GetSynthTxn loads the state of the given staged synthetic transaction.
+func (s *StateDB) GetSynthTxn(txid [32]byte) (*Object, error) {
+	obj, err := s.getObject(bucketStagedSynthTx, "", txid)
 	if errors.Is(err, storage.ErrNotFound) {
 		return nil, fmt.Errorf("%w: no transaction defined for %X", storage.ErrNotFound, txid)
 	}
@@ -303,13 +330,8 @@ func (s *StateDB) GetTransaction(txid []byte) (*Object, error) {
 		return nil, fmt.Errorf("failed to get transaction %X: %v", txid, err)
 	}
 
-	ret := &Object{}
-	err = ret.UnmarshalBinary(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal state for %x", txid)
-	}
-
-	return ret, nil
+	s.logInfo("GetSynthTxn", "txid", logging.AsHex(txid), "entry", logging.AsHex(obj.Entry))
+	return obj, nil
 }
 
 // GetCurrentEntry retrieves the current state object from the database based upon chainId.  Current state either comes
@@ -350,6 +372,7 @@ func (tx *DBTransaction) GetCurrentEntry(chainId []byte) (*Object, error) {
 // of a transaction.  The entry is the state object associated with
 func (tx *DBTransaction) AddStateEntry(chainId *types.Bytes32, txHash *types.Bytes32, object *Object) {
 	tx.state.logInfo("AddStateEntry", "chainId", logging.AsHex(chainId), "txHash", logging.AsHex(txHash), "entry", logging.AsHex(object.Entry))
+	tx.dirty = true
 	begin := time.Now()
 
 	tx.state.TimeBucket += float64(time.Since(begin)) * float64(time.Nanosecond) * 1e-9
@@ -377,7 +400,7 @@ func (tx *DBTransaction) writeTxs(mutex *sync.Mutex, group *sync.WaitGroup) erro
 		txHash := txn.TxId.AsBytes32()
 		if synthTxInfos, ok := tx.transactions.synthTxMap[txHash]; ok {
 			var synthData []byte
-			for _, synthTxInfo := range *synthTxInfos {
+			for _, synthTxInfo := range synthTxInfos {
 				synthData = append(synthData, synthTxInfo.TxId...)
 				synthTxData, err := synthTxInfo.Object.MarshalBinary()
 				if err != nil {
@@ -418,10 +441,6 @@ func (tx *DBTransaction) writeTxs(mutex *sync.Mutex, group *sync.WaitGroup) erro
 		mutex.Unlock()
 	}
 
-	//clear out the transactions after they have been processed
-	tx.transactions.validatedTx = nil
-	tx.transactions.pendingTx = nil
-	tx.transactions.synthTxMap = make(map[types.Bytes32]*[]transactionStateInfo)
 	return nil
 }
 
@@ -489,9 +508,109 @@ func (tx *DBTransaction) writeChainState(group *sync.WaitGroup, mutex *sync.Mute
 	return nil
 }
 
-func (tx *DBTransaction) writeAnchors(mutex *sync.Mutex, blockIndex int64, timestamp time.Time, chainsThatUpdated []types.Bytes32) error {
+func (s *StateDB) GetSynthTxnSigs() ([]SyntheticSignature, error) {
+	b, err := s.GetDB().Key(bucketSynthTxnSigs).Get()
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	sigs := new(SyntheticSignatures)
+	err = sigs.UnmarshalBinary(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return sigs.Signatures, nil
+}
+
+func (tx *DBTransaction) writeSynthTxnSigs() error {
+	sigMap := map[[32]byte]*SyntheticSignature{}
+
+	// Get the current set of signatures
+	sigs, err := tx.state.GetSynthTxnSigs()
+	if err != nil {
+		return err
+	}
+	for _, sig := range sigs {
+		sigMap[sig.Txid] = &sig
+	}
+
+	// Remove any deleted entries
+	for _, txid := range tx.delSynthSigs {
+		delete(sigMap, txid)
+	}
+
+	// Add new entries
+	for _, sig := range tx.addSynthSigs {
+		sigMap[sig.Txid] = sig
+	}
+
+	// Create a sorted array of the transaction IDs
+	txids := make([][32]byte, 0, len(sigMap))
+	for txid := range sigMap {
+		txids = append(txids, txid)
+	}
+	sort.Slice(txids, func(i, j int) bool {
+		return bytes.Compare(txids[i][:], txids[j][:]) < 0
+	})
+
+	// Create a sorted array from the map
+	sigs = make([]SyntheticSignature, 0, len(txids))
+	for _, sig := range sigMap {
+		sigs = append(sigs, *sig)
+	}
+	sort.Slice(sigs, func(i, j int) bool {
+		return bytes.Compare(sigs[i].Txid[:], sigs[j].Txid[:]) < 0
+	})
+
+	// Marshal it
+	b, err := (&SyntheticSignatures{Signatures: sigs}).MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	// Store it in SyntheticTransactionSignatures
+	tx.GetDB().Key(bucketSynthTxnSigs).PutBatch(b)
+	hash := sha256.Sum256(b)
+
+	// Add its hash to the BPT
+	var id [32]byte
+	copy(id[:], []byte(bucketSynthTxnSigs))
+	tx.state.bpt.Bpt.Insert(id, hash)
+	return nil
+}
+
+func (tx *DBTransaction) writeAnchors(blockIndex int64, timestamp time.Time) error {
+	// Collect and sort a list of all chain IDs
+	chains := make([][32]byte, 0, len(tx.updates))
+	for id := range tx.updates {
+		chains = append(chains, id)
+	}
+	sort.Slice(chains, func(i, j int) bool {
+		return bytes.Compare(chains[i][:], chains[j][:]) < 0
+	})
+
+	// Collect and sort a list of all synthetic transaction IDs
+	var txids [][32]byte
+	seen := map[[32]byte]bool{}
+	for _, txns := range tx.transactions.synthTxMap {
+		for _, txn := range txns {
+			txid := txn.TxId.AsBytes32()
+			if seen[txid] {
+				continue
+			}
+			seen[txid] = true
+			txids = append(txids, txid)
+		}
+	}
+	sort.Slice(txids, func(i, j int) bool {
+		return bytes.Compare(txids[i][:], txids[j][:]) < 0
+	})
+
 	// Load the previous anchor chain head
-	prevHead, err := tx.state.getAnchorHead()
+	prevHead, prevCount, err := tx.state.GetAnchorHead()
 	if errors.Is(err, storage.ErrNotFound) {
 		prevHead = &AnchorMetadata{Index: 0}
 	} else if err != nil {
@@ -503,17 +622,8 @@ func (tx *DBTransaction) writeAnchors(mutex *sync.Mutex, blockIndex int64, times
 		panic(fmt.Errorf("Current height is %d but the next block height is %d!", prevHead.Index, blockIndex))
 	}
 
-	// Metadata
-	head := new(AnchorMetadata)
-	head.Index = blockIndex
-	head.PreviousHeight = tx.state.mm.MS.Count
-	head.Timestamp = timestamp
-	head.Chains = make([][32]byte, len(chainsThatUpdated))
-
 	// Add an anchor for each updated chain to the anchor chain
-	for i, chainId := range chainsThatUpdated {
-		head.Chains[i] = chainId
-
+	for _, chainId := range chains {
 		err := tx.state.mm.SetChainID(chainId[:])
 		if err != nil {
 			return err
@@ -527,12 +637,21 @@ func (tx *DBTransaction) writeAnchors(mutex *sync.Mutex, blockIndex int64, times
 		tx.state.mm.AddHash(root)
 	}
 
+	// Add all of the synth txids
+	for _, txid := range txids {
+		tx.state.mm.AddHash(txid[:])
+	}
+
+	// Add the anchor head to the anchor chain
+	head := new(AnchorMetadata)
+	head.Index = blockIndex
+	head.PreviousHeight = prevCount
+	head.Timestamp = timestamp
+	head.Chains = chains
 	data, err := head.MarshalBinary()
 	if err != nil {
 		return err
 	}
-
-	// Add the anchor head to the anchor chain
 	tx.state.mm.AddHash(data)
 
 	// Index the anchor chain against the block index
@@ -540,8 +659,8 @@ func (tx *DBTransaction) writeAnchors(mutex *sync.Mutex, blockIndex int64, times
 
 	// Update the Patricia tree
 	var id [32]byte
-	copy(id[:], []byte(bucketMinorAnchorChain.String()))
-	tx.state.bpt.Bpt.Insert(id, sha256.Sum256(data))
+	copy(id[:], []byte(bucketMinorAnchorChain))
+	tx.state.bpt.Bpt.Insert(id, tx.state.mm.MS.GetMDRoot().Bytes32())
 	return nil
 }
 
@@ -551,28 +670,33 @@ func (tx *DBTransaction) writeBatches() {
 	tx.state.bpt.DBManager.EndBatch()
 }
 
-func (s *StateDB) getAnchorHead() (*AnchorMetadata, error) {
+func (s *StateDB) GetAnchorHead() (*AnchorMetadata, int64, error) {
 	err := s.mm.SetChainID([]byte(bucketMinorAnchorChain))
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if s.mm.MS.Count == 0 {
-		return nil, storage.ErrNotFound
+		return nil, 0, storage.ErrNotFound
 	}
 
 	data, err := s.mm.Get(s.mm.MS.Count - 1)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read anchor chain element %d", s.mm.MS.Count-1)
+		return nil, 0, fmt.Errorf("failed to read anchor chain element %d", s.mm.MS.Count-1)
 	}
 
 	head := new(AnchorMetadata)
 	err = head.UnmarshalBinary(data)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return head, nil
+	return head, s.mm.MS.Count, nil
+}
+
+func (s *StateDB) GetAnchors(start, end int64) ([]types.Bytes32, error) {
+	h, _, err := s.GetChainRange([]byte(bucketMinorAnchorChain), start, end)
+	return h, err
 }
 
 func (s *StateDB) SubnetID() (string, error) {
@@ -584,7 +708,7 @@ func (s *StateDB) SubnetID() (string, error) {
 }
 
 func (s *StateDB) BlockIndex() (int64, error) {
-	head, err := s.getAnchorHead()
+	head, _, err := s.GetAnchorHead()
 	if err != nil {
 		return 0, err
 	}
@@ -595,8 +719,7 @@ func (s *StateDB) BlockIndex() (int64, error) {
 // Commit will push the data to the database and update the patricia trie
 func (tx *DBTransaction) Commit(blockHeight int64, timestamp time.Time) ([]byte, error) {
 	//build a list of keys from the map
-	currentStateCount := len(tx.updates)
-	if currentStateCount == 0 {
+	if !tx.dirty {
 		//only attempt to record the block if we have any data.
 		return tx.RootHash(), nil
 	}
@@ -654,13 +777,13 @@ func (tx *DBTransaction) Commit(blockHeight int64, timestamp time.Time) ([]byte,
 	for _, k := range writeOrder {
 		tx.state.GetDB().Key(k).PutBatch(tx.writes[k])
 	}
-	// The compiler optimizes this into a constant-time operation
-	for k := range tx.writes {
-		delete(tx.writes, k)
+
+	err = tx.writeSynthTxnSigs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to save synth txn signatures: %v", err)
 	}
 
-	// Don't write the anchor during the genesis TX
-	err = tx.writeAnchors(mutex, blockHeight, timestamp, updateOrder)
+	err = tx.writeAnchors(blockHeight, timestamp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make anchor: %v", err)
 	}
@@ -675,6 +798,16 @@ func (tx *DBTransaction) Commit(blockHeight int64, timestamp time.Time) ([]byte,
 	tx.writeBatches()
 
 	tx.updates = make(map[types.Bytes32]*blockUpdates)
+
+	// The compiler optimizes this into a constant-time operation
+	for k := range tx.writes {
+		delete(tx.writes, k)
+	}
+
+	//clear out the transactions after they have been processed
+	tx.transactions.validatedTx = nil
+	tx.transactions.pendingTx = nil
+	tx.transactions.synthTxMap = make(map[types.Bytes32][]transactionStateInfo)
 
 	//return the state of the BPT for the state of the block
 	rh := types.Bytes(tx.state.RootHash()).AsBytes32()

--- a/types/state/StateDB_test.go
+++ b/types/state/StateDB_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"testing"
 
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
+	"github.com/AccumulateNetwork/accumulate/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,4 +32,37 @@ func TestStateDB_GetChainRange(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(N), count)
 	require.Equal(t, end-start, len(hashes))
+}
+
+func TestDBTransaction_writeSynthTxnSigs(t *testing.T) {
+	type fields struct {
+		state        *StateDB
+		updates      map[types.Bytes32]*blockUpdates
+		writes       map[storage.Key][]byte
+		addSynthSigs []*SyntheticSignature
+		delSynthSigs [][32]byte
+		transactions transactionLists
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := &DBTransaction{
+				state:        tt.fields.state,
+				updates:      tt.fields.updates,
+				writes:       tt.fields.writes,
+				addSynthSigs: tt.fields.addSynthSigs,
+				delSynthSigs: tt.fields.delSynthSigs,
+				transactions: tt.fields.transactions,
+			}
+			if err := tx.writeSynthTxnSigs(); (err != nil) != tt.wantErr {
+				t.Errorf("DBTransaction.writeSynthTxnSigs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/types/state/stateTxn.go
+++ b/types/state/stateTxn.go
@@ -8,8 +8,11 @@ import (
 
 type DBTransaction struct {
 	state        *StateDB
+	dirty        bool
 	updates      map[types.Bytes32]*blockUpdates
 	writes       map[storage.Key][]byte
+	addSynthSigs []*SyntheticSignature
+	delSynthSigs [][32]byte
 	transactions transactionLists
 }
 
@@ -21,6 +24,19 @@ func (s *StateDB) Begin() *DBTransaction {
 	dbTx.writes = map[storage.Key][]byte{}
 	dbTx.transactions.reset()
 	return dbTx
+}
+
+// DB returns the transaction's database.
+func (tx *DBTransaction) DB() *StateDB { return tx.state }
+
+func (tx *DBTransaction) AddSynthTxnSig(sig *SyntheticSignature) {
+	tx.dirty = true
+	tx.addSynthSigs = append(tx.addSynthSigs, sig)
+}
+
+func (tx *DBTransaction) DeleteSynthTxnSig(txid [32]byte) {
+	tx.dirty = true
+	tx.delSynthSigs = append(tx.delSynthSigs, txid)
 }
 
 // GetPersistentEntry calls StateDB.GetPersistentEntry(...).

--- a/types/state/types.yml
+++ b/types/state/types.yml
@@ -9,7 +9,16 @@ Object:
     slice:
       type: bytes
 
-# TODO Move this to Protocol
+SyntheticSignatures:
+  fields:
+  - name: Signatures
+    type: slice
+    slice:
+      type: SyntheticSignature
+      marshal-as: self
+
+# TODO Move these to Protocol
+
 AnchorMetadata:
   fields:
   - name: Index
@@ -20,3 +29,14 @@ AnchorMetadata:
     type: time
   - name: Chains
     type: chainSet
+
+SyntheticSignature:
+  fields:
+  - name: Txid
+    type: chain
+  - name: Signature
+    type: bytes
+  - name: PublicKey
+    type: bytes
+  - name: Nonce
+    type: uvarint

--- a/types/state/types_gen.go
+++ b/types/state/types_gen.go
@@ -24,6 +24,17 @@ type Object struct {
 	Roots  [][]byte `json:"roots,omitempty" form:"roots" query:"roots" validate:"required"`
 }
 
+type SyntheticSignature struct {
+	Txid      [32]byte `json:"txid,omitempty" form:"txid" query:"txid" validate:"required"`
+	Signature []byte   `json:"signature,omitempty" form:"signature" query:"signature" validate:"required"`
+	PublicKey []byte   `json:"publicKey,omitempty" form:"publicKey" query:"publicKey" validate:"required"`
+	Nonce     uint64   `json:"nonce,omitempty" form:"nonce" query:"nonce" validate:"required"`
+}
+
+type SyntheticSignatures struct {
+	Signatures []SyntheticSignature `json:"signatures,omitempty" form:"signatures" query:"signatures" validate:"required"`
+}
+
 func (v *AnchorMetadata) BinarySize() int {
 	var n int
 
@@ -55,6 +66,33 @@ func (v *Object) BinarySize() int {
 	return n
 }
 
+func (v *SyntheticSignature) BinarySize() int {
+	var n int
+
+	n += encoding.ChainBinarySize(&v.Txid)
+
+	n += encoding.BytesBinarySize(v.Signature)
+
+	n += encoding.BytesBinarySize(v.PublicKey)
+
+	n += encoding.UvarintBinarySize(v.Nonce)
+
+	return n
+}
+
+func (v *SyntheticSignatures) BinarySize() int {
+	var n int
+
+	n += encoding.UvarintBinarySize(uint64(len(v.Signatures)))
+
+	for _, v := range v.Signatures {
+		n += v.BinarySize()
+
+	}
+
+	return n
+}
+
 func (v *AnchorMetadata) MarshalBinary() ([]byte, error) {
 	var buffer bytes.Buffer
 
@@ -80,6 +118,37 @@ func (v *Object) MarshalBinary() ([]byte, error) {
 	for i, v := range v.Roots {
 		_ = i
 		buffer.Write(encoding.BytesMarshalBinary(v))
+
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (v *SyntheticSignature) MarshalBinary() ([]byte, error) {
+	var buffer bytes.Buffer
+
+	buffer.Write(encoding.ChainMarshalBinary(&v.Txid))
+
+	buffer.Write(encoding.BytesMarshalBinary(v.Signature))
+
+	buffer.Write(encoding.BytesMarshalBinary(v.PublicKey))
+
+	buffer.Write(encoding.UvarintMarshalBinary(v.Nonce))
+
+	return buffer.Bytes(), nil
+}
+
+func (v *SyntheticSignatures) MarshalBinary() ([]byte, error) {
+	var buffer bytes.Buffer
+
+	buffer.Write(encoding.UvarintMarshalBinary(uint64(len(v.Signatures))))
+	for i, v := range v.Signatures {
+		_ = i
+		if b, err := v.MarshalBinary(); err != nil {
+			return nil, fmt.Errorf("error encoding Signatures[%d]: %w", i, err)
+		} else {
+			buffer.Write(b)
+		}
 
 	}
 
@@ -155,6 +224,59 @@ func (v *Object) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+func (v *SyntheticSignature) UnmarshalBinary(data []byte) error {
+	if x, err := encoding.ChainUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Txid: %w", err)
+	} else {
+		v.Txid = x
+	}
+	data = data[encoding.ChainBinarySize(&v.Txid):]
+
+	if x, err := encoding.BytesUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Signature: %w", err)
+	} else {
+		v.Signature = x
+	}
+	data = data[encoding.BytesBinarySize(v.Signature):]
+
+	if x, err := encoding.BytesUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding PublicKey: %w", err)
+	} else {
+		v.PublicKey = x
+	}
+	data = data[encoding.BytesBinarySize(v.PublicKey):]
+
+	if x, err := encoding.UvarintUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Nonce: %w", err)
+	} else {
+		v.Nonce = x
+	}
+	data = data[encoding.UvarintBinarySize(v.Nonce):]
+
+	return nil
+}
+
+func (v *SyntheticSignatures) UnmarshalBinary(data []byte) error {
+	var lenSignatures uint64
+	if x, err := encoding.UvarintUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Signatures: %w", err)
+	} else {
+		lenSignatures = x
+	}
+	data = data[encoding.UvarintBinarySize(lenSignatures):]
+
+	v.Signatures = make([]SyntheticSignature, lenSignatures)
+	for i := range v.Signatures {
+		if err := v.Signatures[i].UnmarshalBinary(data); err != nil {
+			return fmt.Errorf("error decoding Signatures[%d]: %w", i, err)
+		}
+		data = data[v.Signatures[i].BinarySize():]
+
+	}
+
+	return nil
+}
+
 func (v *AnchorMetadata) MarshalJSON() ([]byte, error) {
 	u := struct {
 		Index          int64     `json:"index,omitempty"`
@@ -181,6 +303,20 @@ func (v *Object) MarshalJSON() ([]byte, error) {
 	for i, x := range v.Roots {
 		u.Roots[i] = encoding.BytesToJSON(x)
 	}
+	return json.Marshal(&u)
+}
+
+func (v *SyntheticSignature) MarshalJSON() ([]byte, error) {
+	u := struct {
+		Txid      string  `json:"txid,omitempty"`
+		Signature *string `json:"signature,omitempty"`
+		PublicKey *string `json:"publicKey,omitempty"`
+		Nonce     uint64  `json:"nonce,omitempty"`
+	}{}
+	u.Txid = encoding.ChainToJSON(v.Txid)
+	u.Signature = encoding.BytesToJSON(v.Signature)
+	u.PublicKey = encoding.BytesToJSON(v.PublicKey)
+	u.Nonce = v.Nonce
 	return json.Marshal(&u)
 }
 
@@ -238,5 +374,38 @@ func (v *Object) UnmarshalJSON(data []byte) error {
 			v.Roots[i] = x
 		}
 	}
+	return nil
+}
+
+func (v *SyntheticSignature) UnmarshalJSON(data []byte) error {
+	u := struct {
+		Txid      string  `json:"txid,omitempty"`
+		Signature *string `json:"signature,omitempty"`
+		PublicKey *string `json:"publicKey,omitempty"`
+		Nonce     uint64  `json:"nonce,omitempty"`
+	}{}
+	u.Txid = encoding.ChainToJSON(v.Txid)
+	u.Signature = encoding.BytesToJSON(v.Signature)
+	u.PublicKey = encoding.BytesToJSON(v.PublicKey)
+	u.Nonce = v.Nonce
+	if err := json.Unmarshal(data, &u); err != nil {
+		return err
+	}
+	if x, err := encoding.ChainFromJSON(u.Txid); err != nil {
+		return fmt.Errorf("error decoding Txid: %w", err)
+	} else {
+		v.Txid = x
+	}
+	if x, err := encoding.BytesFromJSON(u.Signature); err != nil {
+		return fmt.Errorf("error decoding Signature: %w", err)
+	} else {
+		v.Signature = x
+	}
+	if x, err := encoding.BytesFromJSON(u.PublicKey); err != nil {
+		return fmt.Errorf("error decoding PublicKey: %w", err)
+	} else {
+		v.PublicKey = x
+	}
+	v.Nonce = u.Nonce
 	return nil
 }

--- a/types/transaction_types.go
+++ b/types/transaction_types.go
@@ -18,7 +18,7 @@ const (
 	TxTypeUnknown TransactionType = 0x00
 
 	// txSynthetic marks the boundary between user and system transactions.
-	txSynthetic TransactionType = 0x30
+	txSynthetic = TxTypeSyntheticSignTransactions
 
 	// txMax is the last defined transaction type.
 	txMax = TxTypeSyntheticGenesis
@@ -85,6 +85,10 @@ const (
 
 // System transactions
 const (
+	// TxTypeSyntheticCreateChain propagates signatures for synthetic
+	// transactions so they can be submitted to the network.
+	TxTypeSyntheticSignTransactions TransactionType = 0x30
+
 	// TxTypeSyntheticCreateChain creates or updates chains.
 	TxTypeSyntheticCreateChain TransactionType = 0x31
 
@@ -144,6 +148,8 @@ func (t TransactionType) String() string {
 		return "addCredits"
 	case TxTypeUpdateKeyPage:
 		return "updateKeyPage"
+	case TxTypeSyntheticSignTransactions:
+		return "syntheticSignTransactions"
 	case TxTypeSyntheticCreateChain:
 		return "syntheticCreateChain"
 	case TxTypeSyntheticWriteData:


### PR DESCRIPTION
This PR correctly implements synthetic production, according to @PaulSnow and @bunfield's comments. It works like this:

- Block 1
  - Deliver
    - Transactions are processed and produce synthetic transactions
  - Commit
    - Synthetic transactions are written to the staging bucket, added to the BPT (hashed), and added to the anchor chain (hashed)
- Block 2
  - BeginBlock
    - The leader scans the anchor chain, generates signatures for the previous block's synthetic transactions, and sends a SyntheticSignTransactions transaction with the signatures to its own BVN
- Block 3
  - Deliver
    - The synthetic transaction signatures are validated
  - Commit
    - The signatures are written to the signatures bucket and added to the BPT (hashed)
- Block 4
  - BeginBlock
    - Pending signed synthetic transactions are batched and transmitted to BVNs
  - Commit
    - Signatures for sent transactions are removed from the signatures bucket
- Block 5 (all BVNs)
  - Synthetic transactions are processed