### PR TITLE
Log filtering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ func Default(net NetworkType, node NodeType) *Config {
 	default:
 		c.Config = *tm.DefaultConfig()
 	}
+	c.LogLevel = "error;main=info;state=info;statesync=info;accumulate=info;executor=info"
 	return c
 }
 

--- a/internal/abci/accumulator.go
+++ b/internal/abci/accumulator.go
@@ -342,7 +342,7 @@ func (app *Accumulator) CheckTx(req abci.RequestCheckTx) (rct abci.ResponseCheck
 	}
 
 	//if we get here, the TX, passed reasonable check, so allow for dispatching to everyone else
-	app.logger.Info("Check succeeded", "type", sub.TransactionType().Name(), "tx", txHash)
+	app.logger.Debug("Check succeeded", "type", sub.TransactionType().Name(), "tx", txHash)
 	return ret
 }
 
@@ -407,7 +407,7 @@ func (app *Accumulator) DeliverTx(req abci.RequestDeliverTx) (rdt abci.ResponseD
 	//now we need to store the data returned by the validator and feed into accumulator
 	app.txct++
 
-	app.logger.Info("Deliver succeeded", "type", sub.TransactionType().Name(), "tx", txHash)
+	app.logger.Debug("Deliver succeeded", "type", sub.TransactionType().Name(), "tx", txHash)
 	return ret
 }
 

--- a/internal/abci/e2e_statedb_test.go
+++ b/internal/abci/e2e_statedb_test.go
@@ -14,7 +14,7 @@ import (
 func TestStateDBConsistency(t *testing.T) {
 	dir := t.TempDir()
 	db := new(badger.DB)
-	err := db.InitDB(filepath.Join(dir, "valacc.db"))
+	err := db.InitDB(filepath.Join(dir, "valacc.db"), nil)
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -36,7 +36,7 @@ import (
 
 func createAppWithMemDB(t testing.TB, addr crypto.Address, logLevel string, doGenesis bool) *fakeNode {
 	db := new(state.StateDB)
-	err := db.Open("memory", true, true)
+	err := db.Open("memory", true, true, nil)
 	require.NoError(t, err)
 
 	return createApp(t, db, addr, logLevel, doGenesis)
@@ -72,8 +72,6 @@ func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel st
 		os.Exit(1)
 	}
 
-	db.SetLogger(logger)
-
 	appChan := make(chan abcitypes.Application)
 	defer close(appChan)
 
@@ -91,7 +89,7 @@ func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel st
 	t.Cleanup(func() { require.NoError(t, relay.Stop()) })
 	n.query = accapi.NewQuery(relay)
 
-	mgr, err := chain.NewBlockValidatorExecutor(n.query, db, bvcKey)
+	mgr, err := chain.NewBlockValidatorExecutor(n.query, db, logger, bvcKey)
 	require.NoError(t, err)
 
 	n.app, err = abci.NewAccumulator(db, addr, mgr, logger)

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -9,10 +9,11 @@ import (
 	"github.com/AccumulateNetwork/accumulate/types"
 	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
 	"github.com/AccumulateNetwork/accumulate/types/state"
+	"github.com/tendermint/tendermint/libs/log"
 )
 
-func NewBlockValidatorExecutor(query *accapi.Query, db *state.StateDB, key ed25519.PrivateKey) (*Executor, error) {
-	return NewExecutor(query, db, key,
+func NewBlockValidatorExecutor(query *accapi.Query, db *state.StateDB, logger log.Logger, key ed25519.PrivateKey) (*Executor, error) {
+	return NewExecutor(query, db, logger, key,
 		CreateIdentity{},
 		WithdrawTokens{},
 		CreateTokenAccount{},
@@ -30,9 +31,8 @@ func NewBlockValidatorExecutor(query *accapi.Query, db *state.StateDB, key ed255
 	)
 }
 
-func NewDirectoryExecutor(query *accapi.Query, db *state.StateDB, key ed25519.PrivateKey) (*Executor, error) {
-	return NewExecutor(query, db, key) // TODO Add DN validators
-
+func NewDirectoryExecutor(query *accapi.Query, db *state.StateDB, logger log.Logger, key ed25519.PrivateKey) (*Executor, error) {
+	return NewExecutor(query, db, logger, key) // TODO Add DN validators
 }
 
 // TxExecutor executes a specific type of transaction.

--- a/internal/chain/synthetic_chain_create_test.go
+++ b/internal/chain/synthetic_chain_create_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSyntheticChainCreate_MultiSlash(t *testing.T) {
 	db := new(state.StateDB)
-	require.NoError(t, db.Open("mem", true, true))
+	require.NoError(t, db.Open("mem", true, true, nil))
 
 	fooKey := generateKey()
 	dbTx := db.Begin()

--- a/internal/chain/synthetic_token_deposit_test.go
+++ b/internal/chain/synthetic_token_deposit_test.go
@@ -23,7 +23,7 @@ func TestSynthTokenDeposit_Anon(t *testing.T) {
 	require.NoError(t, err)
 
 	db := new(state.StateDB)
-	require.NoError(t, db.Open("mem", true, true))
+	require.NoError(t, db.Open("mem", true, true, nil))
 
 	st, err := NewStateManager(db.Begin(), gtx)
 	require.ErrorIs(t, err, storage.ErrNotFound)

--- a/internal/chain/update_key_page_test.go
+++ b/internal/chain/update_key_page_test.go
@@ -32,7 +32,7 @@ func edSigner(key tmed25519.PrivKey, nonce uint64) func(hash []byte) (*transacti
 
 func TestUpdateKeyPage_Priority(t *testing.T) {
 	db := new(state.StateDB)
-	require.NoError(t, db.Open("mem", true, true))
+	require.NoError(t, db.Open("mem", true, true, nil))
 
 	fooKey, testKey, newKey := generateKey(), generateKey(), generateKey()
 	dbtx := db.Begin()

--- a/internal/chain/withdraw_tokens_test.go
+++ b/internal/chain/withdraw_tokens_test.go
@@ -20,7 +20,7 @@ import (
 func TestAnonTokenTransactions(t *testing.T) {
 	tokenUrl := types.String(protocol.AcmeUrl().String())
 	db := &state.StateDB{}
-	err := db.Open("mem", true, true)
+	err := db.Open("mem", true, true, nil)
 	require.NoError(t, err)
 
 	_, privKey, _ := ed25519.GenerateKey(nil)

--- a/internal/logging/console.go
+++ b/internal/logging/console.go
@@ -30,8 +30,8 @@ func NewConsoleWriter(format string) (io.Writer, error) {
 // as plain text for the console. It is based on part of Tendermint's NewTendermintLogger.
 func newConsoleWriter(w io.Writer) *zerolog.ConsoleWriter {
 	return &zerolog.ConsoleWriter{
-		Out:        w,
-		NoColor:    true,
+		Out: w,
+		// NoColor:    true,
 		TimeFormat: time.RFC3339,
 		FormatLevel: func(i interface{}) string {
 			if ll, ok := i.(string); ok {

--- a/internal/logging/filter.go
+++ b/internal/logging/filter.go
@@ -1,0 +1,88 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+func ParseLogLevel(s string, w io.Writer) (string, io.Writer, error) {
+	if !strings.Contains(s, "=") {
+		return s, w, nil
+	}
+
+	var lowestLevel = zerolog.Disabled
+	var defaultLevel = zerolog.Disabled
+	levels := map[string]zerolog.Level{}
+	modules := strings.FieldsFunc(s, func(r rune) bool { return r == ';' })
+	for _, module := range modules {
+		parts := strings.Split(module, "=")
+		level, err := zerolog.ParseLevel(parts[len(parts)-1])
+		if err != nil {
+			return "", nil, err
+		}
+
+		if level < lowestLevel {
+			lowestLevel = level
+		}
+
+		if len(parts) == 1 || parts[0] == "*" {
+			defaultLevel = level
+		} else {
+			levels[parts[0]] = level
+		}
+	}
+
+	w = FilterWriter{
+		Out: w,
+		Predicate: func(level zerolog.Level, event map[string]interface{}) bool {
+			m, _ := event["module"].(string)
+			l, ok := levels[m]
+			if !ok {
+				l = defaultLevel
+			}
+
+			return level >= l
+		},
+	}
+
+	return lowestLevel.String(), w, nil
+}
+
+type FilterWriter struct {
+	Out       io.Writer
+	Predicate func(zerolog.Level, map[string]interface{}) bool
+}
+
+var _ zerolog.LevelWriter = FilterWriter{}
+
+func (w FilterWriter) Write(p []byte) (n int, err error) {
+	return w.WriteLevel(zerolog.NoLevel, p)
+}
+
+func (w FilterWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
+	var evt map[string]interface{}
+	// WARNING If zerolog is compiled with binary_log, this will not work
+	d := json.NewDecoder(bytes.NewReader(p))
+	err = d.Decode(&evt)
+	if err != nil {
+		return n, fmt.Errorf("cannot decode event: %s", err)
+	}
+
+	if level == zerolog.NoLevel {
+		s, ok := evt[zerolog.LevelFieldName].(string)
+		if ok {
+			level, _ = zerolog.ParseLevel(s)
+		}
+	}
+
+	if p := w.Predicate; p != nil && !p(level, evt) {
+		return n, nil
+	}
+
+	return w.Out.Write(p)
+}

--- a/internal/node/init.go
+++ b/internal/node/init.go
@@ -107,7 +107,7 @@ func Init(opts InitOptions) (err error) {
 	genDoc := opts.GenesisDoc
 	if genDoc == nil {
 		db := new(memory.DB)
-		_ = db.InitDB("")
+		_ = db.InitDB("", nil)
 		_ = db.Put(storage.ComputeKey("SubnetID"), []byte(opts.SubnetID))
 		state, _ := db.MarshalBinary()
 		state, err := json.Marshal(state)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -32,12 +32,14 @@ type AppFactory func(*privval.FilePV) (abci.Application, error)
 type Node struct {
 	service.Service
 	Config *config.Config
+	logger log.Logger
 }
 
 // New initializes a Tendermint node for the given ABCI application.
 func New(config *config.Config, app abci.Application, logger log.Logger) (*Node, error) {
 	node := new(Node)
 	node.Config = config
+	node.logger = logger
 
 	// create node
 	var err error
@@ -71,7 +73,7 @@ func (n *Node) Start() error {
 			website.Shutdown(context.Background())
 		}()
 		go func() {
-			stdlog.Printf("Starting website on %s", u.Host)
+			n.logger.Info("Listening", "host", u.Host, "module", "website")
 			err := website.ListenAndServe()
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				stdlog.Fatalf("Failed to start website: %v", err)

--- a/internal/testing/node.go
+++ b/internal/testing/node.go
@@ -70,10 +70,27 @@ func NewBVCNode(dir string, memDB bool, relayTo []string, newZL func(string) zer
 		return nil, nil, nil, fmt.Errorf("failed to load config: %v", err)
 	}
 
+	var zl zerolog.Logger
+	if newZL == nil {
+		w, err := logging.NewConsoleWriter(cfg.LogFormat)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		zl = zerolog.New(w)
+	} else {
+		zl = newZL(cfg.LogFormat)
+	}
+
+	logger, err := logging.NewTendermintLogger(zl, cfg.LogLevel, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to parse log level: %v", err)
+		os.Exit(1)
+	}
+
 	dbPath := filepath.Join(cfg.RootDir, "valacc.db")
 	//ToDo: FIX:::  bvcId := sha256.Sum256([]byte(cfg.Instrumentation.Namespace))
 	sdb := new(state.StateDB)
-	err = sdb.Open(dbPath, memDB, true)
+	err = sdb.Open(dbPath, memDB, true, logger)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to open database %s: %v", dbPath, err)
 	}
@@ -99,29 +116,10 @@ func NewBVCNode(dir string, memDB bool, relayTo []string, newZL func(string) zer
 		return nil, nil, nil, fmt.Errorf("failed to create RPC relay: %v", err)
 	}
 
-	mgr, err := chain.NewBlockValidatorExecutor(api.NewQuery(relay), sdb, pv.Key.PrivKey.Bytes())
+	mgr, err := chain.NewBlockValidatorExecutor(api.NewQuery(relay), sdb, logger, pv.Key.PrivKey.Bytes())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create chain manager: %v", err)
 	}
-
-	var zl zerolog.Logger
-	if newZL == nil {
-		w, err := logging.NewConsoleWriter(cfg.LogFormat)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		zl = zerolog.New(w)
-	} else {
-		zl = newZL(cfg.LogFormat)
-	}
-
-	logger, err := logging.NewTendermintLogger(zl, cfg.LogLevel, false)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to parse log level: %v", err)
-		os.Exit(1)
-	}
-
-	sdb.SetLogger(logger)
 
 	app, err := abci.NewAccumulator(sdb, pv.Key.PubKey.Address(), mgr, logger)
 	if err != nil {

--- a/smt/managed/merklemanager_test.go
+++ b/smt/managed/merklemanager_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMerkleManager_ReadChainHead(t *testing.T) {
 	dbManager := new(database.Manager)
-	if err := dbManager.Init("memory", ""); err != nil {
+	if err := dbManager.Init("memory", "", nil); err != nil {
 		t.Fatal(err)
 	}
 	MM1, err := NewMerkleManager(dbManager, 2)
@@ -44,7 +44,7 @@ func TestIndexing2(t *testing.T) {
 	const testlen = 1024
 
 	dbManager := new(database.Manager)
-	if err := dbManager.Init("memory", ""); err != nil {
+	if err := dbManager.Init("memory", "", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -86,7 +86,7 @@ func TestMerkleManager(t *testing.T) {
 	const testLen = 1024
 
 	dbManager := new(database.Manager)
-	if err := dbManager.Init("memory", ""); err != nil {
+	if err := dbManager.Init("memory", "", nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/smt/managed/merklemanagerrange_test.go
+++ b/smt/managed/merklemanagerrange_test.go
@@ -33,7 +33,7 @@ func TestMerkleManager_GetRange(t *testing.T) {
 	NumTests := int64(40)
 
 	dbManager := new(database.Manager)
-	if err := dbManager.Init("memory", ""); err != nil {
+	if err := dbManager.Init("memory", "", nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/smt/managed/merklemanagerrestart_test.go
+++ b/smt/managed/merklemanagerrestart_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRestart(t *testing.T) {
 
-	dbManager, err := database.NewDBManager("memory", "")
+	dbManager, err := database.NewDBManager("memory", "", nil)
 	if err != nil {
 		t.Fatalf("could not create database. error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestRand(t *testing.T) {
 
 func TestRestartCache(t *testing.T) {
 
-	dbManager, err := database.NewDBManager("memory", "")
+	dbManager, err := database.NewDBManager("memory", "", nil)
 	if err != nil {
 		t.Fatalf("could not create database. error: %v", err)
 	}

--- a/smt/managed/receipt_test.go
+++ b/smt/managed/receipt_test.go
@@ -24,7 +24,7 @@ func TestReceipt(t *testing.T) {
 
 	// Create a memory based database
 	dbManager := new(database.Manager)
-	_ = dbManager.Init("memory", "")
+	_ = dbManager.Init("memory", "", nil)
 	// Create a MerkleManager for the memory database
 	manager, err := NewMerkleManager(dbManager, 4)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestReceiptAll(t *testing.T) {
 
 	// Create a memory based database
 	dbManager := new(database.Manager)
-	_ = dbManager.Init("memory", "")
+	_ = dbManager.Init("memory", "", nil)
 	// Create a MerkleManager for the memory database
 	manager, err := NewMerkleManager(dbManager, 4)
 	if err != nil {
@@ -126,11 +126,11 @@ func GetManager(MarkPower int, temp bool, databaseName string, t *testing.T) (ma
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err = dbManager.Init("badger", dir); err != nil {
+		if err = dbManager.Init("badger", dir, nil); err != nil {
 			t.Fatal("Failed to create database: ", err)
 		}
 	} else {
-		if err := dbManager.Init("badger", databaseName); err != nil {
+		if err := dbManager.Init("badger", databaseName, nil); err != nil {
 			t.Fatal("Failed to create database: ", databaseName)
 		}
 	}

--- a/smt/pmt/manager_test.go
+++ b/smt/pmt/manager_test.go
@@ -44,7 +44,7 @@ func TestManager(t *testing.T) {
 
 	d := 100000
 
-	dbManager, err := database.NewDBManager("memory", "")
+	dbManager, err := database.NewDBManager("memory", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestManagerSeries(t *testing.T) {
 	SetOfValues := make(map[[32]byte][32]byte) // Keep up with key/values we add
 	d := 100                                   // Add 100 entries each pass.
 
-	dbManager, err := database.NewDBManager("memory", "") // One dbManager, memory based
+	dbManager, err := database.NewDBManager("memory", "", nil) // One dbManager, memory based
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/smt/storage/database/manager.go
+++ b/smt/storage/database/manager.go
@@ -59,9 +59,9 @@ func (m *Manager) getInt64(keys ...interface{}) (int64, error) {
 
 // NewDBManager
 // Create and initialize a new database manager
-func NewDBManager(databaseTag, filename string) (*Manager, error) {
+func NewDBManager(databaseTag, filename string, logger storage.Logger) (*Manager, error) {
 	manager := new(Manager)
-	if err := manager.Init(databaseTag, filename); err != nil {
+	if err := manager.Init(databaseTag, filename, logger); err != nil {
 		return nil, err
 	}
 	return manager, nil
@@ -75,17 +75,17 @@ func (m *Manager) init() {
 // Initialize the Manager with a specified underlying database. databaseTag
 // can currently be either badger or memory.  The filename indicates where
 // the database is persisted (ignored by memory).PendingChain
-func (m *Manager) Init(databaseTag, filename string) error {
+func (m *Manager) Init(databaseTag, filename string, logger storage.Logger) error {
 	m.init()
 	switch databaseTag { //                              match with a supported databaseTag
 	case "badger": //                                    Badger database indicated
-		m.DB = new(badger.DB)                         // Create a badger struct
-		if err := m.DB.InitDB(filename); err != nil { // Initialize it with the given filename
+		m.DB = new(badger.DB)                                 // Create a badger struct
+		if err := m.DB.InitDB(filename, logger); err != nil { // Initialize it with the given filename
 			return err
 		}
 	case "memory": //                                    memory database indicated
-		m.DB = new(memory.DB)     //                     Allocate the structure
-		_ = m.DB.InitDB(filename) //                     filename is ignored, but must allocate the underlying map
+		m.DB = new(memory.DB)             //                     Allocate the structure
+		_ = m.DB.InitDB(filename, logger) //                     filename is ignored, but must allocate the underlying map
 	}
 	return nil
 }

--- a/smt/storage/database/manager_test.go
+++ b/smt/storage/database/manager_test.go
@@ -27,7 +27,7 @@ func TestDBManager_TransactionsBadger(t *testing.T) {
 		_ = os.RemoveAll(dir)
 	}()
 
-	if err := dbManager.Init("badger", dir); err != nil {
+	if err := dbManager.Init("badger", dir, nil); err != nil {
 		t.Error(err)
 	} else {
 		writeAndRead(t, dbManager)
@@ -39,7 +39,7 @@ func TestDBManager_TransactionsBadger(t *testing.T) {
 func TestDBManager_TransactionsMemory(t *testing.T) {
 
 	dbManager := new(Manager)
-	_ = dbManager.Init("memory", "")
+	_ = dbManager.Init("memory", "", nil)
 	writeAndReadBatch(t, dbManager)
 	writeAndRead(t, dbManager)
 	dbManager.Close()

--- a/smt/storage/keyvaluedb.go
+++ b/smt/storage/keyvaluedb.go
@@ -1,14 +1,23 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+)
 
 // ErrNotFound is returned by KeyValueDB.Get if the key is not found
 var ErrNotFound = errors.New("not found")
 
 type KeyValueDB interface {
-	Close() error                          // Returns an error if the close fails
-	InitDB(filepath string) error          // Sets up the database, returns error if it fails
-	Get(key Key) (value []byte, err error) // Get key from database, returns ErrNotFound if the key is not found
-	Put(key Key, value []byte) error       // Put the value in the database, throws an error if fails
-	EndBatch(map[Key][]byte) error         // End and commit a batch of transactions
+	Close() error                                // Returns an error if the close fails
+	InitDB(filepath string, logger Logger) error // Sets up the database, returns error if it fails
+	Get(key Key) (value []byte, err error)       // Get key from database, returns ErrNotFound if the key is not found
+	Put(key Key, value []byte) error             // Put the value in the database, throws an error if fails
+	EndBatch(map[Key][]byte) error               // End and commit a batch of transactions
+}
+
+// Logger defines a generic logging interface compatible with Tendermint (stolen from Tendermint).
+type Logger interface {
+	Debug(msg string, keyVals ...interface{})
+	Info(msg string, keyVals ...interface{})
+	Error(msg string, keyVals ...interface{})
 }

--- a/smt/storage/memory/db.go
+++ b/smt/storage/memory/db.go
@@ -82,7 +82,7 @@ func (m *DB) Close() error {
 // a memory database from a file in the future.
 //
 // An existing memory database will be cleared by calling InitDB
-func (m *DB) InitDB(filename string) error {
+func (m *DB) InitDB(filename string, _ storage.Logger) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/smt/storage/memory/db_test.go
+++ b/smt/storage/memory/db_test.go
@@ -14,7 +14,7 @@ func GetKey(key []byte) (dbKey [32]byte) {
 func TestDatabase(t *testing.T) {
 
 	db := new(DB)
-	_ = db.InitDB("test")
+	_ = db.InitDB("test", nil)
 
 	for i := 0; i < 10000; i++ {
 		err := db.Put(GetKey([]byte(fmt.Sprintf("answer %d", i))), []byte(fmt.Sprintf("%x this much data ", i)))


### PR DESCRIPTION
Adds per-module log filtering and updates everything to use the same logger.

To verify, run a node and observe far fewer log messages.