### PR TITLE
Add go vet to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Verify go.mod is tidy
         run: |
           go mod tidy

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -174,7 +174,7 @@ func CreateTX(sender string, args []string) (string, error) {
 
 	//fmt.Println(hex.EncodeToString(pk))
 	tokentx := new(acmeapi.TokenTx)
-	tokentx.From = types.UrlChain{types.String(u.String())}
+	tokentx.From = types.UrlChain{String: types.String(u.String())}
 
 	to := []*acmeapi.TokenTxOutput{}
 	r := &acmeapi.TokenTxOutput{}

--- a/internal/testing/load.go
+++ b/internal/testing/load.go
@@ -174,7 +174,7 @@ func BuildTestTokenTxGenTx(sponsor ed25519.PrivateKey, destAddr string, amount u
 
 	tokenTx := apitypes.TokenTx{}
 
-	tokenTx.From = types.UrlChain{from}
+	tokenTx.From = types.UrlChain{String: from}
 	tokenTx.AddToAccount(types.String(destAddr), amount)
 
 	txData, err := tokenTx.MarshalBinary()

--- a/smt/managed/receipt_test.go
+++ b/smt/managed/receipt_test.go
@@ -28,7 +28,7 @@ func TestReceipt(t *testing.T) {
 	// Create a MerkleManager for the memory database
 	manager, err := NewMerkleManager(dbManager, 4)
 	if err != nil {
-		fmt.Errorf("did not create a merkle manager: %v", err)
+		t.Fatalf("did not create a merkle manager: %v", err)
 	}
 	// populate the database
 	for i := 0; i < testMerkleTreeSize; i++ {
@@ -139,7 +139,7 @@ func GetManager(MarkPower int, temp bool, databaseName string, t *testing.T) (ma
 	var err error
 	manager, err = NewMerkleManager(dbManager, 2)
 	if err != nil {
-		fmt.Errorf("did not create a merkle manager: %v", err)
+		t.Fatalf("did not create a merkle manager: %v", err)
 	}
 	return manager, dir
 }
@@ -179,14 +179,17 @@ func GenerateReceipts(manager *MerkleManager, receiptCount int64, t *testing.T) 
 					j < 0 || j >= int(manager.MS.Count) || //        Or j is out of range
 					j < i { //                                    Or if the anchor is before the element
 					if r != nil { //                            then you should not be able to generate a receipt
-						t.Fatal("Should not be able to generate a receipt")
+						t.Error("Should not be able to generate a receipt")
+						return
 					}
 				} else {
 					if r == nil {
-						t.Fatal("Failed to generate receipt", i, j)
+						t.Error("Failed to generate receipt", i, j)
+						return
 					}
 					if !r.Validate() {
-						t.Fatal("Receipt fails for element ", i, " anchor ", j)
+						t.Error("Receipt fails for element ", i, " anchor ", j)
+						return
 					}
 					atomic.AddInt64(total, 1)
 				}

--- a/types/api/TokenTx.go
+++ b/types/api/TokenTx.go
@@ -31,14 +31,14 @@ type TokenTxOutput struct {
 
 func NewTokenTx(from types.String, to ...*TokenTxOutput) *TokenTx {
 	tx := &TokenTx{}
-	tx.From = types.UrlChain{from}
+	tx.From = types.UrlChain{String: from}
 	tx.To = to
 	return tx
 }
 
 func NewTokenTxOutput(url types.String, amount uint64) *TokenTxOutput {
 	txo := new(TokenTxOutput)
-	txo.URL = types.UrlChain{url}
+	txo.URL = types.UrlChain{String: url}
 	txo.Amount = amount
 	return txo
 }

--- a/types/state/Transaction_test.go
+++ b/types/state/Transaction_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestTransactionState(t *testing.T) {
 	nts1 := api.TokenTx{}
-	nts1.From = types.UrlChain{"RedWagon/myAccount"}
+	nts1.From = types.UrlChain{String: "RedWagon/myAccount"}
 	nts1.AddToAccount("BlueWagon/account", uint64(100*100000000))
 
 	we := accapi.NewWalletEntry()


### PR DESCRIPTION
Fixes `go vet ./...` warnings and adds `go vet ./...` to CI.

Fixes #291