### PR TITLE
ci: make a template for validation jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ deploy 4/4:
   variables:   { HOST: 172.31.13.8,   NETWORK: Yellowstone,  NODE: 1, DN_NODE: 3, BIN: accumulated-linux-arm64 }
   environment: { url: 'http://172.31.13.8:8080',   name: Yellowstone/1 }
 
-validate:
+.validate:
   stage: validate
   only: [develop] # only run on the main branch
   needs: [deploy 1/4, deploy 2/4, deploy 3/4, deploy 4/4]
@@ -137,6 +137,9 @@ validate:
   variables:
     ACC_API: https://devnet.accumulatenetwork.io/v1
     MNEMONIC: bench industry mirror above van second avoid maximum genius person swear cage
+
+validate:
+  extends: .validate
   script:
   - apt-get -y update && apt-get -y install jq
   - ./scripts/validate.sh


### PR DESCRIPTION
This makes no functional changes. It creates a job template that makes it easier to create additional validation jobs.