### PR TITLE
Fetch TX history across mark points

### DIFF
--- a/internal/chain/executor_query.go
+++ b/internal/chain/executor_query.go
@@ -138,7 +138,7 @@ func (m *Executor) Query(q *query.Query) (k, v []byte, err *protocol.Error) {
 		}
 
 		thr := query.ResponseTxHistory{}
-		txids, maxAmt, err := m.db.GetTxRange(&txh.ChainId, txh.Start, txh.Start+txh.Limit)
+		txids, maxAmt, err := m.db.GetChainRange(txh.ChainId[:], txh.Start, txh.Start+txh.Limit)
 		if err != nil {
 			return nil, nil, &protocol.Error{Code: protocol.CodeTxnHistory, Message: fmt.Errorf("error obtaining txid range %v", err)}
 		}

--- a/types/state/StateDB_test.go
+++ b/types/state/StateDB_test.go
@@ -1,0 +1,33 @@
+package state
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateDB_GetChainRange(t *testing.T) {
+	s := new(StateDB)
+	require.NoError(t, s.Open("", true, false, nil))
+
+	// Set the mark frequency to 4
+	s.mm.MarkPower = 2
+	s.mm.MarkFreq = 1 << s.mm.MarkPower
+	s.mm.MarkMask = s.mm.MarkFreq - 1
+
+	id := []byte(t.Name())
+	require.NoError(t, s.mm.SetChainID(id))
+
+	const N = 10
+	for i := byte(0); i < N; i++ {
+		h := sha256.Sum256([]byte{i})
+		s.mm.AddHash(h[:])
+	}
+
+	const start, end = 1, 6
+	hashes, count, err := s.GetChainRange(id, start, end)
+	require.NoError(t, err)
+	require.Equal(t, int64(N), count)
+	require.Equal(t, end-start, len(hashes))
+}


### PR DESCRIPTION
Update `StateDB.GetChainRange` to work if the specified range crosses a mark point.