### PR TITLE
chore: update credit to dollar conversion rate

### DIFF
--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -362,7 +362,7 @@ func TestSendCreditsFromAdiAccountToMultiSig(t *testing.T) {
 	ks := n.GetSigSpec("foo/sigspec0")
 	acct := n.GetTokenAccount("foo/tokens")
 	require.Equal(t, int64(55), ks.CreditBalance.Int64())
-	require.Equal(t, int64(protocol.AcmePrecision*1e2-protocol.AcmePrecision/protocol.CreditsPerDollar*55), acct.Balance.Int64())
+	require.Equal(t, int64(protocol.AcmePrecision*1e2-protocol.AcmePrecision/protocol.CreditsPerFiatUnit*55), acct.Balance.Int64())
 }
 
 func TestCreateSigSpec(t *testing.T) {

--- a/internal/chain/add_credits.go
+++ b/internal/chain/add_credits.go
@@ -23,17 +23,11 @@ func (AddCredits) Validate(st *StateManager, tx *transactions.GenTransaction) er
 		return fmt.Errorf("invalid payload: %v", err)
 	}
 
-	// This fixes the conversion between ACME tokens and fiat currency to
-	// 1:1, as in $1 per 1 ACME token.
-	//
-	// TODO This should be retrieved from an oracle.
-	const DollarsPerAcmeToken = 1
-
 	// tokens = credits / (credits per dollar) / (dollars per token)
 	amount := types.NewAmount(protocol.AcmePrecision) // Do everything with ACME precision
 	amount.Mul(int64(body.Amount))                    // Amount in credits
-	amount.Div(protocol.CreditsPerDollar)             // Amount in dollars
-	amount.Div(DollarsPerAcmeToken)                   // Amount in tokens
+	amount.Div(protocol.CreditsPerFiatUnit)           // Amount in dollars
+	amount.Div(protocol.FiatUnitsPerAcmeToken)        // Amount in tokens
 
 	recvUrl, err := url.Parse(body.Recipient)
 	if err != nil {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -24,10 +24,22 @@ func AcmeUrl() *url.URL {
 // AcmePrecision is the precision of ACME token amounts.
 const AcmePrecision = 1e8
 
-// CreditsPerDollar is the conversion rate from 1 unit of fiat currency to
-// credits. We call this 'dollars' because it's easier to write, and we are most
-// likely going to use USD idefinitely.
-const CreditsPerDollar = 1e2
+// FiatUnitsPerAcmeToken fixes the conversion between ACME tokens and fiat
+// currency to 1:1, as in $1 per 1 ACME token.
+//
+// As soon as we have an oracle, this must be removed.
+const FiatUnitsPerAcmeToken = 1
+
+// CreditPrecision is the precision of credit balances.
+const CreditPrecision = 1e2
+
+// CreditsPerFiatUnit is the conversion rate from credit balances to fiat
+// currency. We expect to use USD indefinitely as the fiat currency.
+//
+// 100 credits converts to 1 dollar, but we charge down to 0.01 credits, so the
+// actual conversion rate of the credit balance field to dollars is is 10,000 to
+// 1.
+const CreditsPerFiatUnit = 1e2 * CreditPrecision
 
 // AnonymousAddress returns an anonymous address for the given public key and
 // token URL as `acc://<key-hash-and-checksum>/<token-url>`.


### PR DESCRIPTION
We need to be able to charge fees down to 1/100th of a cent. The simplest way to do this is to change the conversion rate to 1 dollar = 10,000 credits.