### PR TITLE
fix: reload state DB after loading genesis state

### DIFF
--- a/smt/storage/memory/db.go
+++ b/smt/storage/memory/db.go
@@ -52,7 +52,7 @@ func (m *DB) Export() map[storage.Key][]byte {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	ex := make(map[storage.Key][]byte)
+	ex := make(map[storage.Key][]byte, len(m.entries))
 	for k, v := range m.entries {
 		ex[k] = v
 	}


### PR DESCRIPTION
InitChain loads state from the genesis doc (AC-622, AC-632). However, the BPT root hash does not get updated. This PR adds a call to `StateDB.Load` to reload the BPT from the database. It also adds a sanity check.

To verify, create and launch a BVN node, wait for it to settle, stop it, and restart it. On `develop` this will fail. With this PR, it will not fail.