### PR TITLE
Wait for TX to complete

### DIFF
--- a/cmd/accumulated/program.go
+++ b/cmd/accumulated/program.go
@@ -229,7 +229,9 @@ func (p *Program) Start(s service.Service) error {
 		}
 	}
 
-	jrpcOpts.Query = api.NewQueryDispatch(clients)
+	jrpcOpts.Query = api.NewQueryDispatch(clients, api.QuerierOptions{
+		TxMaxWaitTime: cfg.Accumulate.API.TxMaxWaitTime,
+	})
 
 	jrpc, err := api.NewJrpc(jrpcOpts)
 	if err != nil {

--- a/cmd/cli/cmd/account_test.go
+++ b/cmd/cli/cmd/account_test.go
@@ -40,7 +40,7 @@ func testCase3_1(t *testing.T, tc *testCmd) {
 	t.Helper()
 
 	commandLine := fmt.Sprintf("account create acc://RedWagon red1 acc://RedWagon/acct acc://acme acc://RedWagon/ssg0")
-	r, err := tc.execute(t, commandLine)
+	r, err := tc.executeTx(t, commandLine)
 	require.NoError(t, err)
 
 	t.Log(r)

--- a/cmd/cli/cmd/adi_test.go
+++ b/cmd/cli/cmd/adi_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/AccumulateNetwork/accumulate/protocol"
 	"github.com/stretchr/testify/require"
@@ -34,15 +33,9 @@ func testCase2_1(t *testing.T, tc *testCmd) {
 	//faucet the lite account to make sure there are tokens available
 	testCase5_1(t, tc)
 
-	//need to wait a sec to make sure faucet tx settles
-	time.Sleep(2 * time.Second)
-
 	commandLine := fmt.Sprintf("adi create %s acc://RedWagon red1", liteAccounts[0])
-	_, err := tc.execute(t, commandLine)
+	_, err := tc.executeTx(t, commandLine)
 	require.NoError(t, err)
-
-	//need to wait 2 secs to make sure adi create settles
-	time.Sleep(2 * time.Second)
 
 	//if this doesn't fail, then adi is created
 	_, err = tc.execute(t, "adi directory acc://RedWagon")
@@ -91,13 +84,12 @@ func testCase2_5(t *testing.T, tc *testCmd) {
 
 	//uncomment after V2 upgrade
 	//commandLine := fmt.Sprintf("adi create %s acc://RedWagon red5 blue green", liteAccounts[0])
-	//r, err := tc.execute(t, commandLine)
+	//r, err := tc.executeTx(t, commandLine)
 	//require.NoError(t, err)
 	//
 	//var res map[string]interface{}
 	//require.NoError(t, json.Unmarshal([]byte(r), &res))
 	//
-	//time.Sleep(time.Second)
 	////now query the txid
 	//commandLine = fmt.Sprintf("get txid %v", res["txid"])
 	//r, err = tc.execute(t, commandLine)
@@ -110,12 +102,10 @@ func testCase2_6(t *testing.T, tc *testCmd) {
 	t.Helper()
 
 	commandLine := fmt.Sprintf("adi create acc://RedWagon red1 acc://Redstone red2")
-	r, err := tc.execute(t, commandLine)
+	r, err := tc.executeTx(t, commandLine)
 	require.NoError(t, err)
 
 	t.Log(r)
-	//need to wait 2 secs to make sure adi create settles
-	time.Sleep(2 * time.Second)
 
 	//if this doesn't fail, then adi is created
 	r, err = tc.execute(t, "adi directory acc://Redstone")

--- a/cmd/cli/cmd/faucet_test.go
+++ b/cmd/cli/cmd/faucet_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
-	"time"
 
 	api2 "github.com/AccumulateNetwork/accumulate/types/api"
 	"github.com/AccumulateNetwork/accumulate/types/api/response"
@@ -25,14 +24,18 @@ func testCase5_1(t *testing.T, tc *testCmd) {
 		beenFauceted = append(beenFauceted, bal == "1000000000")
 	}
 
+	var results []string
 	for i := range liteAccounts {
 		commandLine := fmt.Sprintf("faucet %s", liteAccounts[i])
-		_, err := tc.execute(t, commandLine)
+		r, err := tc.execute(t, commandLine)
 		require.NoError(t, err)
+		results = append(results, r)
 	}
 
 	//wait for settlement
-	time.Sleep(2 * time.Second)
+	for _, r := range results {
+		waitForTxns(t, tc, r)
+	}
 
 	for i := range liteAccounts {
 		//now query the account to make sure each account has 10 acme.

--- a/cmd/cli/cmd/page_test.go
+++ b/cmd/cli/cmd/page_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,18 +24,16 @@ func testCase4_1(t *testing.T, tc *testCmd) {
 	t.Helper()
 
 	commandLine := fmt.Sprintf("page create acc://RedWagon red1 acc://RedWagon/page1 red2")
-	r, err := tc.execute(t, commandLine)
+	r, err := tc.executeTx(t, commandLine)
 	require.NoError(t, err)
 
 	t.Log(r)
 
 	commandLine = fmt.Sprintf("page create acc://RedWagon red1 acc://RedWagon/page2 red3")
-	r, err = tc.execute(t, commandLine)
+	r, err = tc.executeTx(t, commandLine)
 	require.NoError(t, err)
 
 	t.Log(r)
-
-	time.Sleep(2 * time.Second)
 }
 
 //testCase4_2 Create a key book from unbounded key pages
@@ -44,12 +41,10 @@ func testCase4_2(t *testing.T, tc *testCmd) {
 	t.Helper()
 
 	commandLine := fmt.Sprintf("book create acc://RedWagon red1 acc://RedWagon/book acc://RedWagon/page1 acc://RedWagon/page2")
-	r, err := tc.execute(t, commandLine)
+	r, err := tc.executeTx(t, commandLine)
 	require.NoError(t, err)
 
 	t.Log(r)
-
-	time.Sleep(2 * time.Second)
 }
 
 //testCase4_3 Add a key to a key page
@@ -61,12 +56,10 @@ func testCase4_3(t *testing.T, tc *testCmd) {
 
 	//uncomment after key page fix
 	//commandLine := fmt.Sprintf("-d page key add acc://RedWagon/page1 red2 red4")
-	//r, err := tc.execute(t, commandLine)
+	//r, err := tc.executeTx(t, commandLine)
 	//require.NoError(t, err)
 	//
 	//t.Log(r)
-	//
-	//time.Sleep(2 * time.Second)
 }
 
 //testCase4_4 Create additional key pages sponsored by a book
@@ -74,12 +67,10 @@ func testCase4_4(t *testing.T, tc *testCmd) {
 	t.Helper()
 
 	commandLine := fmt.Sprintf("page create acc://RedWagon/book red2 acc://RedWagon/page3 red5")
-	r, err := tc.execute(t, commandLine)
+	r, err := tc.executeTx(t, commandLine)
 	require.NoError(t, err)
 
 	t.Log(r)
-
-	time.Sleep(2 * time.Second)
 }
 
 //testCase4_5 Create an adi token account bound to a key book
@@ -87,12 +78,10 @@ func testCase4_5(t *testing.T, tc *testCmd) {
 	t.Helper()
 
 	commandLine := fmt.Sprintf("account create acc://RedWagon red1 acc://RedWagon/acct2 acc://ACME acc://RedWagon/book")
-	r, err := tc.execute(t, commandLine)
+	r, err := tc.executeTx(t, commandLine)
 	require.NoError(t, err)
 
 	t.Log(r)
-
-	time.Sleep(2 * time.Second)
 }
 
 //testCase4_6 Delete a key in a key page
@@ -105,12 +94,10 @@ func testCase4_6(t *testing.T, tc *testCmd) {
 	//uncomment after fix key page remove
 	////remove red4
 	//commandLine := fmt.Sprintf("page key remove acc://RedWagon/page2 red3 red4")
-	//r, err := tc.execute(t, commandLine)
+	//r, err := tc.executeTx(t, commandLine)
 	//require.NoError(t, err)
 	//
 	//t.Log(r)
-	//
-	//time.Sleep(2 * time.Second)
 }
 
 //testCase4_7 update a key in a key page
@@ -123,12 +110,10 @@ func testCase4_7(t *testing.T, tc *testCmd) {
 	//uncomment after key page update fix.
 	////replace key3 with key 4
 	//commandLine := fmt.Sprintf("page key update acc://RedWagon/page2 red3 red3 red4")
-	//r, err := tc.execute(t, commandLine)
+	//r, err := tc.executeTx(t, commandLine)
 	//require.NoError(t, err)
 	//
 	//t.Log(r)
-	//
-	//time.Sleep(2 * time.Second)
 }
 
 //testCase4_8 Sign a transaction with a secondary key page
@@ -139,15 +124,12 @@ func testCase4_8(t *testing.T, tc *testCmd) {
 	return
 
 	//commandLine := fmt.Sprintf("tx create %s acc://RedWagon/acct2 5", liteAccounts[0])
-	//r, err := tc.execute(t, commandLine)
+	//r, err := tc.executeTx(t, commandLine)
 	//require.NoError(t, err)
 	//
-	//time.Sleep(2 * time.Second)
 	//commandLine = fmt.Sprintf("tx create acc://RedWagon/acct2 red3 1 1 acc://Redwagon/acct 1.1234")
-	//r, err = tc.execute(t, commandLine)
+	//r, err = tc.executeTx(t, commandLine)
 	//require.NoError(t, err)
 	//
 	//t.Log(r)
-	//
-	//time.Sleep(2 * time.Second)
 }

--- a/cmd/cli/cmd/root_test.go
+++ b/cmd/cli/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	net2 "net"
@@ -21,12 +22,10 @@ import (
 	"github.com/AccumulateNetwork/accumulate/config"
 	"github.com/AccumulateNetwork/accumulate/internal/api"
 	api2 "github.com/AccumulateNetwork/accumulate/internal/api/v2"
-	"github.com/AccumulateNetwork/accumulate/internal/logging"
 	"github.com/AccumulateNetwork/accumulate/internal/node"
 	"github.com/AccumulateNetwork/accumulate/internal/relay"
 	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
 	"github.com/AccumulateNetwork/accumulate/networks"
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/net"
@@ -108,10 +107,6 @@ func NewTestBVNN(t *testing.T, defaultWorkDir string) (int, int) {
 	cfg.Accumulate.Networks[0] =
 		fmt.Sprintf("tcp://%s:%d", opts.RemoteIP[0], opts.Port+networks.TmRpcPortOffset)
 
-	newLogger := func(s string) zerolog.Logger {
-		return logging.NewTestZeroLogger(t, s)
-	}
-
 	require.NoError(t, node.Init(opts))               // Configure
 	nodeDir := filepath.Join(defaultWorkDir, "Node0") //
 	cfg, err = config.Load(nodeDir)                   // Modify configuration
@@ -119,11 +114,13 @@ func NewTestBVNN(t *testing.T, defaultWorkDir string) (int, int) {
 	cfg.Accumulate.WebsiteEnabled = false             // Disable the website
 	cfg.Instrumentation.Prometheus = false            // Disable prometheus: https://github.com/tendermint/tendermint/issues/7076
 	cfg.Consensus.TimeoutCommit = time.Second / 10    // Increase block frequency
-	require.NoError(t, config.Store(cfg))             //
+	cfg.Accumulate.API.TxMaxWaitTime = 10 * time.Second
+	cfg.LogLevel = "error;main=info;state=info;statesync=info;accumulate=info;executor=info"
+	require.NoError(t, config.Store(cfg))
 
-	bvnNode, _, _, err := acctesting.NewBVCNode(nodeDir, true, nil, newLogger, t.Cleanup) // Initialize
-	require.NoError(t, err)                                                               //
-	require.NoError(t, bvnNode.Start())                                                   // Launch
+	bvnNode, _, _, err := acctesting.NewBVCNode(nodeDir, true, nil, nil, t.Cleanup) // Initialize
+	require.NoError(t, err)                                                         //
+	require.NoError(t, bvnNode.Start())                                             // Launch
 	relayTo := []string{cfg.RPC.ListenAddress}
 	relay, err := relay.NewWith(relayTo...)
 
@@ -168,7 +165,9 @@ func NewTestBVNN(t *testing.T, defaultWorkDir string) (int, int) {
 		}
 	}
 
-	jrpcOpts.Query = api2.NewQueryDispatch(clients)
+	jrpcOpts.Query = api2.NewQueryDispatch(clients, api2.QuerierOptions{
+		TxMaxWaitTime: cfg.Accumulate.API.TxMaxWaitTime,
+	})
 
 	jrpc, err := api2.NewJrpc(jrpcOpts)
 	if err != nil {
@@ -245,6 +244,14 @@ func (c *testCmd) execute(t *testing.T, cmdLine string) (string, error) {
 	return string(ret), err
 }
 
+func (c *testCmd) executeTx(t *testing.T, cmdLine string) (string, error) {
+	out, err := c.execute(t, cmdLine)
+	if err == nil {
+		waitForTxns(t, c, out)
+	}
+	return out, err
+}
+
 // listenHttpUrl
 // takes a string such as `http://localhost:123` and creates a TCP listener.
 func listenHttpUrl(s string) (net2.Listener, bool, error) {
@@ -273,4 +280,17 @@ func listenHttpUrl(s string) (net2.Listener, bool, error) {
 	}
 
 	return l, secure, nil
+}
+
+func waitForTxns(t *testing.T, tc *testCmd, jsonRes string) {
+	t.Helper()
+
+	var res struct {
+		Txid string
+	}
+	require.NoError(t, json.Unmarshal([]byte(jsonRes), &res))
+
+	commandLine := fmt.Sprintf("tx get --wait 10s --wait-synth 10s %s", res.Txid)
+	_, err := tc.execute(t, commandLine)
+	require.NoError(t, err)
 }

--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -11,7 +13,9 @@ import (
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	"github.com/AccumulateNetwork/accumulate/types"
 	acmeapi "github.com/AccumulateNetwork/accumulate/types/api"
+	"github.com/AccumulateNetwork/jsonrpc2/v15"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 )
 
 var txCmd = &cobra.Command{
@@ -55,6 +59,16 @@ var txCmd = &cobra.Command{
 	},
 }
 
+var (
+	TxWait      time.Duration
+	TxWaitSynth time.Duration
+)
+
+func init() {
+	txCmd.Flags().DurationVarP(&TxWait, "wait", "w", 0, "Wait for the transaction to complete")
+	txCmd.Flags().DurationVar(&TxWaitSynth, "wait-synth", 0, "Wait for synthetic transactions to complete")
+}
+
 func PrintTXGet() {
 	fmt.Println("  accumulate tx get [txid]			Get token transaction by txid")
 }
@@ -73,29 +87,93 @@ func PrintTX() {
 	PrintTXHistoryGet()
 }
 
-func GetTX(hash string) (string, error) {
+func getTX(hash []byte, wait time.Duration) (*api2.QueryResponse, error) {
+	var res api2.QueryResponse
+	var err error
 
-	var res acmeapi.APIDataResponse
-	var hashbytes types.Bytes32
+	params := new(api2.TxnQuery)
+	params.Txid = hash
 
-	params := new(acmeapi.TokenTxRequest)
-	err := hashbytes.FromString(hash)
-	if err != nil {
-		return "", err
+	if wait > 0 {
+		params.Wait = wait
 	}
-	params.Hash = hashbytes
 
 	data, err := json.Marshal(params)
 	jsondata := json.RawMessage(data)
 	if err != nil {
+		return nil, err
+	}
+
+	err = Client.RequestV2(context.Background(), "query-tx", jsondata, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func GetTX(hash string) (string, error) {
+	txid, err := hex.DecodeString(hash)
+	if err != nil {
 		return "", err
 	}
 
-	if err := Client.Request(context.Background(), "token-tx", jsondata, &res); err != nil {
+	t := Client.Timeout
+	defer func() { Client.Timeout = t }()
+
+	if TxWait > 0 {
+		Client.Timeout = TxWait * 11 / 10
+	}
+
+	res, err := getTX(txid, TxWait)
+	if err != nil {
+		var rpcErr jsonrpc2.Error
+		if errors.As(err, &rpcErr) {
+			return PrintJsonRpcError(err)
+		}
+		return "", err
+	}
+
+	out, err := PrintQueryResponseV2(res)
+	if err != nil {
+		return "", err
+	}
+
+	if TxWaitSynth == 0 || len(res.SyntheticTxids) == 0 {
+		return out, nil
+	}
+
+	if TxWaitSynth > 0 {
+		Client.Timeout = TxWaitSynth * 11 / 10
+	}
+
+	errg := new(errgroup.Group)
+	for _, txid := range res.SyntheticTxids {
+		txid := txid // Do not capture the loop variable in the closure
+		errg.Go(func() error {
+			res, err := getTX(txid[:], TxWaitSynth)
+			if err != nil {
+				return err
+			}
+
+			o, err := PrintQueryResponseV2(res)
+			if err != nil {
+				return err
+			}
+
+			out += o
+			return nil
+		})
+	}
+	err = errg.Wait()
+	if err != nil {
+		var rpcErr jsonrpc2.Error
+		if errors.As(err, &rpcErr) {
+			return PrintJsonRpcError(err)
+		}
 		return PrintJsonRpcError(err)
 	}
 
-	return PrintQueryResponse(&res)
+	return out, nil
 }
 
 func GetTXHistory(accountUrl string, s string, e string) (string, error) {

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -409,11 +409,70 @@ func printGeneralTransactionParameters(res *acmeapi.APIDataResponse) string {
 	out += fmt.Sprintf("  - Transaction           : %x\n", res.TxId.AsBytes32())
 	out += fmt.Sprintf("  - Signer Url            : %s\n", res.Sponsor)
 	out += fmt.Sprintf("  - Signature             : %x\n", res.Sig.Bytes())
-	out += fmt.Sprintf("  - Signer Key            : %x\n", res.Signer.PublicKey.Bytes())
-	out += fmt.Sprintf("  - Signer Nonce          : %d\n", res.Signer.Nonce)
+	if res.Signer != nil {
+		out += fmt.Sprintf("  - Signer Key            : %x\n", res.Signer.PublicKey.Bytes())
+		out += fmt.Sprintf("  - Signer Nonce          : %d\n", res.Signer.Nonce)
+	}
 	out += fmt.Sprintf("  - Key Page              : %d (height) / %d (index)\n", res.KeyPage.Height, res.KeyPage.Index)
 	out += fmt.Sprintf("===\n")
 	return out
+}
+
+func PrintQueryResponseV2(v2 *api2.QueryResponse) (string, error) {
+	if WantJsonOutput {
+		data, err := json.Marshal(v2)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+
+	v1 := new(acmeapi.APIDataResponse)
+	v1.Type = types.String(v2.Type)
+	if v2.MerkleState != nil {
+		v1.MerkleState = new(acmeapi.MerkleState)
+		v1.MerkleState.Count = v2.MerkleState.Count
+		v1.MerkleState.Roots = make([]types.Bytes, len(v2.MerkleState.Roots))
+		for i, r := range v2.MerkleState.Roots {
+			v1.MerkleState.Roots[i] = r
+		}
+	}
+	v1.Sponsor = types.String(v2.Sponsor)
+	if v2.KeyPage != nil {
+		v1.KeyPage = new(acmeapi.APIRequestKeyPage)
+		v1.KeyPage.Height = v2.KeyPage.Height
+		v1.KeyPage.Index = v2.KeyPage.Index
+	}
+	v1.TxId = (*types.Bytes)(&v2.Txid)
+	if v2.Signer != nil {
+		v1.Signer = new(acmeapi.Signer)
+		v1.Signer.PublicKey = types.Bytes(v2.Signer.PublicKey).AsBytes32()
+		v1.Signer.Nonce = v2.Signer.Nonce
+	}
+	sig := types.Bytes(v2.Sig).AsBytes64()
+	v1.Sig = &sig
+
+	b, err := json.Marshal(v2.Data)
+	if err != nil {
+		return "", err
+	}
+	v1.Data = (*json.RawMessage)(&b)
+
+	b, err = json.Marshal(v2.Status)
+	if err != nil {
+		return "", err
+	}
+	v1.Status = (*json.RawMessage)(&b)
+
+	out, err := PrintQueryResponse(v1)
+	if err != nil {
+		return "", err
+	}
+
+	for i, txid := range v2.SyntheticTxids {
+		out += fmt.Sprintf("  - Synthetic Transaction %d : %x\n", i, txid)
+	}
+	return out, nil
 }
 
 func PrintQueryResponse(res *acmeapi.APIDataResponse) (string, error) {
@@ -560,7 +619,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) (string, error) {
 				out += fmt.Sprintf("\t%d\t%d\t%x\t%s", i, k.Nonce, k.PublicKey, keyName)
 			}
 			return out, nil
-		case "tokenTx":
+		case "withdrawTokens":
 			tx := response.TokenTx{}
 			err := json.Unmarshal(*res.Data, &tx)
 			if err != nil {
@@ -581,7 +640,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) (string, error) {
 
 			out += printGeneralTransactionParameters(res)
 			return out, nil
-		case "syntheticTokenDeposit":
+		case "syntheticDepositTokens":
 			deposit := synthetic.TokenTransactionDeposit{}
 			err := json.Unmarshal(*res.Data, &deposit)
 
@@ -601,9 +660,9 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) (string, error) {
 			return out, nil
 
 		default:
+			return "", fmt.Errorf("unknown response type %q", res.Type)
 		}
 	}
-	return "", nil
 }
 
 func resolveKeyPageUrl(adi string, chainId []byte) (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/pelletier/go-toml"
 	"github.com/spf13/viper"
@@ -25,19 +26,22 @@ const (
 	Follower  NodeType = "follower"
 )
 
+const DefaultLogLevels = "error;main=info;state=info;statesync=info;accumulate=debug;executor=info"
+
 func Default(net NetworkType, node NodeType) *Config {
 	c := new(Config)
 	c.Accumulate.Type = net
 	c.Accumulate.API.PrometheusServer = "http://18.119.26.7:9090"
 	c.Accumulate.SentryDSN = "https://glet_78c3bf45d009794a4d9b0c990a1f1ed5@gitlab.com/api/v4/error_tracking/collector/29762666"
 	c.Accumulate.WebsiteEnabled = true
+	c.Accumulate.API.TxMaxWaitTime = 10 * time.Second
 	switch node {
 	case Validator:
 		c.Config = *tm.DefaultValidatorConfig()
 	default:
 		c.Config = *tm.DefaultConfig()
 	}
-	c.LogLevel = "error;main=info;state=info;statesync=info;accumulate=info;executor=info"
+	c.LogLevel = DefaultLogLevels
 	return c
 }
 
@@ -63,11 +67,12 @@ type RPC struct {
 }
 
 type API struct {
-	PrometheusServer  string `toml:"prometheus-server" mapstructure:"prometheus-server"`
-	EnableSubscribeTX bool   `toml:"enable-subscribe-tx" mapstructure:"enable-subscribe-tx"`
-	JSONListenAddress string `toml:"json-listen-address" mapstructure:"json-listen-address"`
-	RESTListenAddress string `toml:"rest-listen-address" mapstructure:"rest-listen-address"`
-	DebugJSONRPC      bool   `toml:"debug-jsonrpc" mapstructure:"debug-jsonrpc"`
+	TxMaxWaitTime     time.Duration `toml:"tx-max-wait-time" mapstructure:"tx-max-wait-time"`
+	PrometheusServer  string        `toml:"prometheus-server" mapstructure:"prometheus-server"`
+	EnableSubscribeTX bool          `toml:"enable-subscribe-tx" mapstructure:"enable-subscribe-tx"`
+	JSONListenAddress string        `toml:"json-listen-address" mapstructure:"json-listen-address"`
+	RESTListenAddress string        `toml:"rest-listen-address" mapstructure:"rest-listen-address"`
+	DebugJSONRPC      bool          `toml:"debug-jsonrpc" mapstructure:"debug-jsonrpc"`
 }
 
 func Load(dir string) (*Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/ybbus/jsonrpc/v2 v2.1.6
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.7

--- a/internal/api/v2/jrpc_query.go
+++ b/internal/api/v2/jrpc_query.go
@@ -37,13 +37,13 @@ func (m *JrpcMethods) QueryChain(_ context.Context, params json.RawMessage) inte
 }
 
 func (m *JrpcMethods) QueryTx(_ context.Context, params json.RawMessage) interface{} {
-	req := new(TxIdQuery)
+	req := new(TxnQuery)
 	err := m.parse(params, req)
 	if err != nil {
 		return err
 	}
 
-	return jrpcFormatQuery(m.opts.Query.QueryTx(req.Txid))
+	return jrpcFormatQuery(m.opts.Query.QueryTx(req.Txid, req.Wait))
 }
 
 func (m *JrpcMethods) QueryTxHistory(_ context.Context, params json.RawMessage) interface{} {

--- a/internal/api/v2/query.go
+++ b/internal/api/v2/query.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding"
+	"time"
 
 	"github.com/AccumulateNetwork/accumulate/types"
 )
@@ -11,10 +12,14 @@ type queryRequest interface {
 	Type() types.QueryType
 }
 
-func NewQueryDirect(c ABCIQueryClient) Querier {
-	return queryDirect{c}
+type QuerierOptions struct {
+	TxMaxWaitTime time.Duration
 }
 
-func NewQueryDispatch(c []ABCIQueryClient) Querier {
-	return queryDispatch{c}
+func NewQueryDirect(c ABCIQueryClient, opts QuerierOptions) Querier {
+	return &queryDirect{opts, c}
+}
+
+func NewQueryDispatch(c []ABCIQueryClient, opts QuerierOptions) Querier {
+	return &queryDispatch{opts, c}
 }

--- a/internal/api/v2/query_dispatch.go
+++ b/internal/api/v2/query_dispatch.go
@@ -3,21 +3,23 @@ package api
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	"github.com/AccumulateNetwork/accumulate/smt/storage"
 )
 
 type queryDispatch struct {
+	QuerierOptions
 	clients []ABCIQueryClient
 }
 
-func (q queryDispatch) direct(i uint64) queryDirect {
+func (q *queryDispatch) direct(i uint64) *queryDirect {
 	i = i % uint64(len(q.clients))
-	return queryDirect{q.clients[i]}
+	return &queryDirect{q.QuerierOptions, q.clients[i]}
 }
 
-func (q queryDispatch) routing(s string) (uint64, error) {
+func (q *queryDispatch) routing(s string) (uint64, error) {
 	u, err := url.Parse(s)
 	if err != nil {
 		return 0, fmt.Errorf("%w: %v", ErrInvalidUrl, err)
@@ -26,10 +28,10 @@ func (q queryDispatch) routing(s string) (uint64, error) {
 	return u.Routing(), nil
 }
 
-func (q queryDispatch) queryAll(query func(queryDirect) (*QueryResponse, error)) ([]*QueryResponse, error) {
+func (q *queryDispatch) queryAll(query func(*queryDirect) (*QueryResponse, error)) ([]*QueryResponse, error) {
 	res := make([]*QueryResponse, 0, 1)
 	for _, c := range q.clients {
-		r, err := query(queryDirect{c})
+		r, err := query(&queryDirect{q.QuerierOptions, c})
 		if err == nil {
 			res = append(res, r)
 		} else if !errors.Is(err, storage.ErrNotFound) {
@@ -44,7 +46,7 @@ func (q queryDispatch) queryAll(query func(queryDirect) (*QueryResponse, error))
 	return res, nil
 }
 
-func (q queryDispatch) QueryUrl(url string) (*QueryResponse, error) {
+func (q *queryDispatch) QueryUrl(url string) (*QueryResponse, error) {
 	r, err := q.routing(url)
 	if err != nil {
 		return nil, err
@@ -53,8 +55,8 @@ func (q queryDispatch) QueryUrl(url string) (*QueryResponse, error) {
 	return q.direct(r).QueryUrl(url)
 }
 
-func (q queryDispatch) QueryChain(id []byte) (*QueryResponse, error) {
-	res, err := q.queryAll(func(q queryDirect) (*QueryResponse, error) {
+func (q *queryDispatch) QueryChain(id []byte) (*QueryResponse, error) {
+	res, err := q.queryAll(func(q *queryDirect) (*QueryResponse, error) {
 		return q.QueryChain(id)
 	})
 	if err != nil {
@@ -68,7 +70,7 @@ func (q queryDispatch) QueryChain(id []byte) (*QueryResponse, error) {
 	return res[0], nil
 }
 
-func (q queryDispatch) QueryDirectory(url string, queryOptions *QueryOptions) (*QueryResponse, error) {
+func (q *queryDispatch) QueryDirectory(url string, queryOptions *QueryOptions) (*QueryResponse, error) {
 	r, err := q.routing(url)
 	if err != nil {
 		return nil, err
@@ -77,9 +79,9 @@ func (q queryDispatch) QueryDirectory(url string, queryOptions *QueryOptions) (*
 	return q.direct(r).QueryDirectory(url, queryOptions)
 }
 
-func (q queryDispatch) QueryTx(id []byte) (*QueryResponse, error) {
-	res, err := q.queryAll(func(q queryDirect) (*QueryResponse, error) {
-		return q.QueryTx(id)
+func (q *queryDispatch) QueryTx(id []byte, wait time.Duration) (*QueryResponse, error) {
+	res, err := q.queryAll(func(q *queryDirect) (*QueryResponse, error) {
+		return q.QueryTx(id, wait)
 	})
 	if err != nil {
 		return nil, err
@@ -92,7 +94,7 @@ func (q queryDispatch) QueryTx(id []byte) (*QueryResponse, error) {
 	return res[0], nil
 }
 
-func (q queryDispatch) QueryTxHistory(url string, start, count int64) (*QueryMultiResponse, error) {
+func (q *queryDispatch) QueryTxHistory(url string, start, count int64) (*QueryMultiResponse, error) {
 	r, err := q.routing(url)
 	if err != nil {
 		return nil, err

--- a/internal/api/v2/types.go
+++ b/internal/api/v2/types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"github.com/tendermint/tendermint/libs/bytes"
 	core "github.com/tendermint/tendermint/rpc/core/types"
@@ -13,9 +14,9 @@ import (
 
 type Querier interface {
 	QueryUrl(url string) (*QueryResponse, error)
-	QueryDirectory(url string, queryOptions *QueryOptions) (*QueryResponse, error)
+	QueryDirectory(url string, opts *QueryOptions) (*QueryResponse, error)
 	QueryChain(id []byte) (*QueryResponse, error)
-	QueryTx(id []byte) (*QueryResponse, error)
+	QueryTx(id []byte, wait time.Duration) (*QueryResponse, error)
 	QueryTxHistory(url string, start, count int64) (*QueryMultiResponse, error)
 }
 

--- a/internal/api/v2/types.yml
+++ b/internal/api/v2/types.yml
@@ -13,16 +13,20 @@ QueryResponse:
       type: string
     - name: KeyPage
       type: KeyPage
+      pointer: true
       marshal-as: self
     - name: Txid
       type: bytes
     - name: Signer
       type: Signer
+      pointer: true
       marshal-as: self
     - name: Sig
       type: bytes
     - name: Status
       type: any
+    - name: SyntheticTxids
+      type: chainSet
 
 MerkleState:
   non-binary: true
@@ -141,11 +145,14 @@ QueryOptions:
       type: bool
       optional: true
 
-TxIdQuery:
+TxnQuery:
   non-binary: true
   fields:
   - name: Txid
     type: bytes
+  - name: Wait
+    type: duration
+    optional: true
 
 ChainIdQuery:
   non-binary: true

--- a/internal/api/v2/unmarshal.go
+++ b/internal/api/v2/unmarshal.go
@@ -75,6 +75,8 @@ func unmarshalTxPayload(b []byte) (protocol.TransactionPayload, error) {
 	case types.TxTypeCreateIdentity:
 		payload = new(protocol.IdentityCreate)
 	case types.TxTypeCreateToken:
+		payload = new(protocol.CreateToken)
+	case types.TxTypeCreateTokenAccount:
 		payload = new(protocol.TokenAccountCreate)
 	case types.TxTypeCreateKeyPage:
 		payload = new(protocol.CreateKeyPage)
@@ -119,7 +121,7 @@ func unmarshalTxResponse(mainData, pendData []byte) (*state.Transaction, *state.
 	}
 
 	err = pendObj.UnmarshalBinary(pendData)
-	if err != nil {
+	if err == nil {
 		pend = new(state.PendingTransaction)
 		err = pendObj.As(pend)
 		if err != nil {

--- a/internal/mock/api/types.go
+++ b/internal/mock/api/types.go
@@ -7,6 +7,7 @@ package mock_api
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	api "github.com/AccumulateNetwork/accumulate/internal/api/v2"
 	gomock "github.com/golang/mock/gomock"
@@ -54,33 +55,33 @@ func (mr *MockQuerierMockRecorder) QueryChain(id interface{}) *gomock.Call {
 }
 
 // QueryDirectory mocks base method.
-func (m *MockQuerier) QueryDirectory(url string, queryOptions *api.QueryOptions) (*api.QueryResponse, error) {
+func (m *MockQuerier) QueryDirectory(url string, opts *api.QueryOptions) (*api.QueryResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryDirectory", url, queryOptions)
+	ret := m.ctrl.Call(m, "QueryDirectory", url, opts)
 	ret0, _ := ret[0].(*api.QueryResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueryDirectory indicates an expected call of QueryDirectory.
-func (mr *MockQuerierMockRecorder) QueryDirectory(url, queryOptions interface{}) *gomock.Call {
+func (mr *MockQuerierMockRecorder) QueryDirectory(url, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryDirectory", reflect.TypeOf((*MockQuerier)(nil).QueryDirectory), url, queryOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryDirectory", reflect.TypeOf((*MockQuerier)(nil).QueryDirectory), url, opts)
 }
 
 // QueryTx mocks base method.
-func (m *MockQuerier) QueryTx(id []byte) (*api.QueryResponse, error) {
+func (m *MockQuerier) QueryTx(id []byte, wait time.Duration) (*api.QueryResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryTx", id)
+	ret := m.ctrl.Call(m, "QueryTx", id, wait)
 	ret0, _ := ret[0].(*api.QueryResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // QueryTx indicates an expected call of QueryTx.
-func (mr *MockQuerierMockRecorder) QueryTx(id interface{}) *gomock.Call {
+func (mr *MockQuerierMockRecorder) QueryTx(id, wait interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryTx", reflect.TypeOf((*MockQuerier)(nil).QueryTx), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryTx", reflect.TypeOf((*MockQuerier)(nil).QueryTx), id, wait)
 }
 
 // QueryTxHistory mocks base method.

--- a/internal/testing/e2e/tests.go
+++ b/internal/testing/e2e/tests.go
@@ -43,13 +43,13 @@ func (s *Suite) TestCreateAnonAccount() {
 	}
 
 	var total int64
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1; i++ {
 		if i > 2 && testing.Short() {
 			break
 		}
 
 		exch := apitypes.NewTokenTx(types.String(senderUrl.String()))
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 1; i++ {
 			if i > 2 && testing.Short() {
 				break
 			}

--- a/internal/testing/node.go
+++ b/internal/testing/node.go
@@ -77,6 +77,7 @@ func NewBVCNode(dir string, memDB bool, relayTo []string, newZL func(string) zer
 		if err != nil {
 			return nil, nil, nil, err
 		}
+		cfg.LogLevel, w, err = logging.ParseLogLevel(cfg.LogLevel, w)
 		zl = zerolog.New(w)
 	} else {
 		zl = newZL(cfg.LogFormat)


### PR DESCRIPTION
- Add `wait` parameter to API v2 `query-tx`, which will poll every half second for the TX status, for up to 10 seconds (configurable)
- Add `--wait` to `cli tx get`, which is passed to `query-tx` as `wait`
- Add `--wait-synth` to `cli tx get`, which will iterate over the transaction's synthetic transactions, if any, and `query-tx` each one, with `wait`