### PR TITLE
test: close badger after stopping the ABCI

### DIFF
--- a/internal/abci/e2e_statedb_test.go
+++ b/internal/abci/e2e_statedb_test.go
@@ -16,7 +16,10 @@ func TestStateDBConsistency(t *testing.T) {
 	db := new(badger.DB)
 	err := db.InitDB(filepath.Join(dir, "valacc.db"), nil)
 	require.NoError(t, err)
-	defer db.Close()
+
+	// Call during test cleanup. This ensures that the app client is shutdown
+	// before the database is closed.
+	t.Cleanup(func() { db.Close() })
 
 	sdb := new(state.StateDB)
 	require.NoError(t, sdb.Load(db, true))


### PR DESCRIPTION
If badger is closed first, there's a race condition where the ABCI app client might attempt to read from badger after it's closed. Waiting until test cleanup to close badger should avoid this.