### PR TITLE
Fix query by chain ID

### DIFF
--- a/internal/chain/executor_query.go
+++ b/internal/chain/executor_query.go
@@ -206,7 +206,7 @@ func (m *Executor) Query(q *query.Query) (k, v []byte, err *protocol.Error) {
 		}
 	case types.QueryTypeChainId:
 		chr := query.RequestByChainId{}
-		err := chr.UnmarshalBinary(chr.ChainId[:])
+		err := chr.UnmarshalBinary(q.Content)
 		if err != nil {
 			return nil, nil, &protocol.Error{Code: protocol.CodeUnMarshallingError, Message: err}
 		}

--- a/internal/cmd/getchain/getchain.go
+++ b/internal/cmd/getchain/getchain.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AccumulateNetwork/accumulate/internal/url"
+)
+
+func main() {
+	u, err := url.Parse(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Resource chain: %X\n", u.ResourceChain())
+	fmt.Printf("Identity chain: %X\n", u.IdentityChain())
+}


### PR DESCRIPTION
Fix the executor's implementation of query by chain ID.

Verify with `curl -s -X POST --data '{ "jsonrpc": "2.0", "id": 0, "method": "query-chain", "params": { "chainId": "'${CHAIN}'" } }' -H 'content-type:application/json;' ${SERVER}`