### PR TITLE
Transaction dispatcher (for the transaction executor)

### DIFF
--- a/cmd/accumulated/program.go
+++ b/cmd/accumulated/program.go
@@ -143,11 +143,12 @@ func (p *Program) Start(s service.Service) error {
 	clientProxy := node.NewLocalClient()
 
 	execOpts := chain.ExecutorOptions{
-		Query:  apiv1.NewQuery(p.relay),
-		Local:  clientProxy,
-		DB:     p.db,
-		Logger: logger,
-		Key:    pv.Key.PrivKey.Bytes(),
+		Local:           clientProxy,
+		DB:              p.db,
+		Logger:          logger,
+		Key:             pv.Key.PrivKey.Bytes(),
+		Directory:       cfg.Accumulate.Directory,
+		BlockValidators: cfg.Accumulate.Networks,
 	}
 	var exec *chain.Executor
 	switch cfg.Accumulate.Type {
@@ -216,7 +217,7 @@ func (p *Program) Start(s service.Service) error {
 			clients[i] = lclient
 
 		default:
-			addr, err := networks.GetRpcAddr(net, networks.TmRpcPortOffset)
+			addr, err := networks.GetRpcAddr(net)
 			if err != nil {
 				return fmt.Errorf("invalid network name or address: %v", err)
 			}

--- a/cmd/cli/cmd/root_test.go
+++ b/cmd/cli/cmd/root_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/AccumulateNetwork/accumulate/config"
 	"github.com/AccumulateNetwork/accumulate/internal/api"
 	api2 "github.com/AccumulateNetwork/accumulate/internal/api/v2"
+	"github.com/AccumulateNetwork/accumulate/internal/logging"
 	"github.com/AccumulateNetwork/accumulate/internal/node"
 	"github.com/AccumulateNetwork/accumulate/internal/relay"
 	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
@@ -118,9 +119,14 @@ func NewTestBVNN(t *testing.T, defaultWorkDir string) (int, int) {
 	cfg.LogLevel = "error;main=info;state=info;statesync=info;accumulate=info;executor=info"
 	require.NoError(t, config.Store(cfg))
 
-	bvnNode, _, _, err := acctesting.NewBVCNode(nodeDir, true, nil, nil, t.Cleanup) // Initialize
-	require.NoError(t, err)                                                         //
-	require.NoError(t, bvnNode.Start())                                             // Launch
+	opts2 := acctesting.BVNNOptions{
+		Dir:       nodeDir,
+		LogWriter: logging.TestLogWriter(t),
+	}
+
+	bvnNode, _, _, err := acctesting.NewBVNN(opts2, t.Cleanup) // Initialize
+	require.NoError(t, err)                                    //
+	require.NoError(t, bvnNode.Start())                        // Launch
 	relayTo := []string{cfg.RPC.ListenAddress}
 	relay, err := relay.NewWith(relayTo...)
 
@@ -152,7 +158,7 @@ func NewTestBVNN(t *testing.T, defaultWorkDir string) (int, int) {
 			clients[i] = lclient
 
 		default:
-			addr, err := networks.GetRpcAddr(net, networks.TmRpcPortOffset)
+			addr, err := networks.GetRpcAddr(net)
 			if err != nil {
 				t.Fatalf("invalid network name or address: %v", err)
 			}

--- a/internal/abci/e2e_proofs_test.go
+++ b/internal/abci/e2e_proofs_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestProofADI(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 
 	// Setup keys and the lite account
 	liteKey, adiKey := generateKey(), generateKey()

--- a/internal/abci/e2e_statedb_test.go
+++ b/internal/abci/e2e_statedb_test.go
@@ -21,7 +21,7 @@ func TestStateDBConsistency(t *testing.T) {
 	sdb := new(state.StateDB)
 	require.NoError(t, sdb.Load(db, true))
 
-	n := createApp(t, sdb, crypto.Address{}, "error", true)
+	n := createApp(t, sdb, crypto.Address{}, true)
 	n.testLiteTx(10)
 
 	height, err := sdb.BlockIndex()
@@ -40,6 +40,6 @@ func TestStateDBConsistency(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%X", rootHash), fmt.Sprintf("%X", sdb.RootHash()), "Hash does not match after load from disk")
 
 	// Recreate the app and try to do more transactions
-	n = createApp(t, sdb, crypto.Address{}, "error", false)
+	n = createApp(t, sdb, crypto.Address{}, false)
 	n.testLiteTx(10)
 }

--- a/internal/abci/e2e_test.go
+++ b/internal/abci/e2e_test.go
@@ -29,13 +29,13 @@ type Tx = transactions.GenTransaction
 func TestEndToEndSuite(t *testing.T) {
 	suite.Run(t, e2e.NewSuite(func(s *e2e.Suite) e2e.DUT {
 		// Recreate the app for each test
-		n := createAppWithMemDB(s.T(), crypto.Address{}, "error", true)
+		n := createAppWithMemDB(s.T(), crypto.Address{}, true)
 		return e2eDUT{n}
 	}))
 }
 
 func BenchmarkFaucetAndLiteTx(b *testing.B) {
-	n := createAppWithMemDB(b, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(b, crypto.Address{}, true)
 
 	sponsor := generateKey()
 	recipient := generateKey()
@@ -69,7 +69,7 @@ func BenchmarkFaucetAndLiteTx(b *testing.B) {
 
 func TestCreateLiteAccount(t *testing.T) {
 	var count = 11
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	originAddr, balances := n.testLiteTx(count)
 	require.Equal(t, int64(5e4*acctesting.TokenMx-count*1000), n.GetLiteTokenAccount(originAddr).Balance.Int64())
 	for addr, bal := range balances {
@@ -116,7 +116,7 @@ func (n *fakeNode) testLiteTx(count int) (string, map[string]int64) {
 }
 
 func TestFaucet(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	alice := generateKey()
 	aliceUrl := lite.GenerateAcmeAddress(alice.PubKey().Bytes())
 
@@ -134,7 +134,7 @@ func TestFaucet(t *testing.T) {
 }
 
 func TestAnchorChain(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	liteAccount := generateKey()
 	dbTx := n.db.Begin()
 	require.NoError(n.t, acctesting.CreateLiteTokenAccount(dbTx, liteAccount, 5e4))
@@ -183,7 +183,7 @@ func TestAnchorChain(t *testing.T) {
 }
 
 func TestCreateADI(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 
 	liteAccount := generateKey()
 	newAdi := generateKey()
@@ -227,7 +227,7 @@ func TestCreateADI(t *testing.T) {
 
 func TestCreateAdiTokenAccount(t *testing.T) {
 	t.Run("Default Key Book", func(t *testing.T) {
-		n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+		n := createAppWithMemDB(t, crypto.Address{}, true)
 		adiKey := generateKey()
 		dbTx := n.db.Begin()
 		require.NoError(t, acctesting.CreateADI(dbTx, adiKey, "FooBar"))
@@ -255,7 +255,7 @@ func TestCreateAdiTokenAccount(t *testing.T) {
 	})
 
 	t.Run("Custom Key Book", func(t *testing.T) {
-		n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+		n := createAppWithMemDB(t, crypto.Address{}, true)
 		adiKey, pageKey := generateKey(), generateKey()
 		dbTx := n.db.Begin()
 		require.NoError(t, acctesting.CreateADI(dbTx, adiKey, "FooBar"))
@@ -285,7 +285,7 @@ func TestCreateAdiTokenAccount(t *testing.T) {
 }
 
 func TestLiteAccountTx(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	alice, bob, charlie := generateKey(), generateKey(), generateKey()
 	dbTx := n.db.Begin()
 	require.NoError(n.t, acctesting.CreateLiteTokenAccount(dbTx, alice, 5e4))
@@ -313,7 +313,7 @@ func TestLiteAccountTx(t *testing.T) {
 }
 
 func TestAdiAccountTx(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey, barKey := generateKey(), generateKey()
 	dbTx := n.db.Begin()
 	require.NoError(t, acctesting.CreateADI(dbTx, fooKey, "foo"))
@@ -336,7 +336,7 @@ func TestAdiAccountTx(t *testing.T) {
 }
 
 func TestSendCreditsFromAdiAccountToMultiSig(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey := generateKey()
 	dbTx := n.db.Begin()
 	require.NoError(t, acctesting.CreateADI(dbTx, fooKey, "foo"))
@@ -360,7 +360,7 @@ func TestSendCreditsFromAdiAccountToMultiSig(t *testing.T) {
 }
 
 func TestCreateKeyPage(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey, testKey := generateKey(), generateKey()
 	dbTx := n.db.Begin()
 	require.NoError(t, acctesting.CreateADI(dbTx, fooKey, "foo"))
@@ -387,7 +387,7 @@ func TestCreateKeyPage(t *testing.T) {
 }
 
 func TestCreateKeyBook(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey, testKey := generateKey(), generateKey()
 	dbTx := n.db.Begin()
 	require.NoError(t, acctesting.CreateADI(dbTx, fooKey, "foo"))
@@ -419,7 +419,7 @@ func TestCreateKeyBook(t *testing.T) {
 }
 
 func TestAddKeyPage(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey, testKey1, testKey2 := generateKey(), generateKey(), generateKey()
 
 	u := n.ParseUrl("foo/ssg1")
@@ -455,7 +455,7 @@ func TestAddKeyPage(t *testing.T) {
 }
 
 func TestAddKey(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey, testKey := generateKey(), generateKey()
 
 	dbTx := n.db.Begin()
@@ -481,7 +481,7 @@ func TestAddKey(t *testing.T) {
 }
 
 func TestUpdateKey(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey, testKey := generateKey(), generateKey()
 
 	dbTx := n.db.Begin()
@@ -508,7 +508,7 @@ func TestUpdateKey(t *testing.T) {
 }
 
 func TestRemoveKey(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	fooKey, testKey1, testKey2 := generateKey(), generateKey(), generateKey()
 
 	dbTx := n.db.Begin()
@@ -533,7 +533,7 @@ func TestRemoveKey(t *testing.T) {
 }
 
 func TestSignatorHeight(t *testing.T) {
-	n := createAppWithMemDB(t, crypto.Address{}, "error", true)
+	n := createAppWithMemDB(t, crypto.Address{}, true)
 	liteKey, fooKey := generateKey(), generateKey()
 
 	liteUrl, err := protocol.LiteAddress(liteKey.PubKey().Bytes(), "ACME")

--- a/internal/abci/utils_test.go
+++ b/internal/abci/utils_test.go
@@ -38,37 +38,24 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
-func createAppWithMemDB(t testing.TB, addr crypto.Address, logLevel string, doGenesis bool) *fakeNode {
+func createAppWithMemDB(t testing.TB, addr crypto.Address, doGenesis bool) *fakeNode {
 	db := new(state.StateDB)
 	err := db.Open("memory", true, true, nil)
 	require.NoError(t, err)
 
-	return createApp(t, db, addr, logLevel, doGenesis)
+	return createApp(t, db, addr, doGenesis)
 }
 
-func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel string, doGenesis bool) *fakeNode {
+func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, doGenesis bool) *fakeNode {
 	_, bvcKey, _ := ed25519.GenerateKey(rand)
 
 	n := new(fakeNode)
 	n.t = t
 	n.db = db
 
-	zl := logging.NewTestZeroLogger(t, "plain")
-	zl = zl.Hook(logging.ExcludeMessages("GetIndex", "WriteIndex"))
-	zl = zl.Hook(logging.BodyHook(func(e *zerolog.Event, _ zerolog.Level, body map[string]interface{}) {
-		module, ok := body["module"].(string)
-		if !ok {
-			return
-		}
-
-		switch module {
-		case "db":
-		// case "accumulate", "db":
-		// OK
-		default:
-			e.Discard()
-		}
-	}))
+	logWriter := logging.TestLogWriter(t)("plain")
+	logLevel, logWriter, err := logging.ParseLogLevel(config.DefaultLogLevels, logWriter)
+	zl := zerolog.New(logWriter)
 
 	logger, err := logging.NewTendermintLogger(zl, logLevel, false)
 	if err != nil {
@@ -94,18 +81,20 @@ func createApp(t testing.TB, db *state.StateDB, addr crypto.Address, logLevel st
 	n.query = accapi.NewQuery(relay)
 
 	mgr, err := chain.NewBlockValidatorExecutor(chain.ExecutorOptions{
-		Query:  n.query,
-		Local:  n.client,
-		DB:     n.db,
-		Logger: logger,
-		Key:    bvcKey,
+		Local:           n.client,
+		DB:              n.db,
+		Logger:          logger,
+		Key:             bvcKey,
+		BlockValidators: []string{"self"},
 	})
 	require.NoError(t, err)
 
 	n.app, err = abci.NewAccumulator(db, addr, mgr, logger)
 	require.NoError(t, err)
 	appChan <- n.app
-	n.app.(*abci.Accumulator).OnFatal(func(err error) { require.NoError(t, err) })
+	n.app.(*abci.Accumulator).OnFatal(func(err error) {
+		require.NoError(t, err)
+	})
 
 	t.Cleanup(func() { n.client.Shutdown() })
 

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -287,14 +287,8 @@ func TestFaucet(t *testing.T) {
 	jsonapi := NewTest(t, query)
 
 	res := jsonapi.Faucet(context.Background(), params)
-	data, err := json.Marshal(res)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Println(string(data))
-
-	//allow the transaction to settle.
-	time.Sleep(time.Second)
+	require.IsType(t, (*api.APIDataResponse)(nil), res)
+	require.NoError(t, acctesting.WaitForTxV1(query, res.(*acmeapi.APIDataResponse)))
 
 	//readback the result.
 	resp, err := query.GetChainStateByUrl(string(req.URL))

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -14,7 +14,6 @@ import (
 	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
 	"github.com/AccumulateNetwork/accumulate/networks"
 	"github.com/AccumulateNetwork/accumulate/types/state"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/privval"
 	rpc "github.com/tendermint/tendermint/rpc/client/http"
@@ -34,21 +33,21 @@ func startBVC(t *testing.T, dir string) (*state.StateDB, *privval.FilePV, *Query
 	cfg.Accumulate.API.EnableSubscribeTX = true
 	cfg.Accumulate.Networks[0] = fmt.Sprintf("tcp://%s:%d", opts.RemoteIP[0], opts.Port+networks.TmRpcPortOffset)
 
-	newLogger := func(s string) zerolog.Logger {
-		return logging.NewTestZeroLogger(t, s)
+	opts2 := acctesting.BVNNOptions{
+		Dir:       filepath.Join(dir, "Node0"),
+		LogWriter: logging.TestLogWriter(t),
 	}
 
-	require.NoError(t, node.Init(opts))                                                    // Configure
-	nodeDir := filepath.Join(dir, "Node0")                                                 //
-	cfg, err = config.Load(nodeDir)                                                        // Modify configuration
-	require.NoError(t, err)                                                                //
-	cfg.Accumulate.WebsiteEnabled = false                                                  // Disable the website
-	cfg.Instrumentation.Prometheus = false                                                 // Disable prometheus: https://github.com/tendermint/tendermint/issues/7076
-	cfg.Consensus.TimeoutCommit = time.Second / 10                                         // ~10 blocks per second
-	require.NoError(t, config.Store(cfg))                                                  //
-	node, sdb, pv, err := acctesting.NewBVCNode(nodeDir, false, nil, newLogger, t.Cleanup) // Initialize
-	require.NoError(t, err)                                                                //
-	require.NoError(t, node.Start())                                                       // Launch
+	require.NoError(t, node.Init(opts))                        // Configure
+	cfg, err = config.Load(opts2.Dir)                          // Modify configuration
+	require.NoError(t, err)                                    //
+	cfg.Accumulate.WebsiteEnabled = false                      // Disable the website
+	cfg.Instrumentation.Prometheus = false                     // Disable prometheus: https://github.com/tendermint/tendermint/issues/7076
+	cfg.Consensus.TimeoutCommit = time.Second / 10             // ~10 blocks per second
+	require.NoError(t, config.Store(cfg))                      //
+	node, sdb, pv, err := acctesting.NewBVNN(opts2, t.Cleanup) // Initialize
+	require.NoError(t, err)                                    //
+	require.NoError(t, node.Start())                           // Launch
 
 	t.Cleanup(func() { require.NoError(t, node.Stop()) })
 

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -11,7 +11,7 @@ import (
 
 // NewBlockValidatorExecutor creates a new Executor for a block validator node.
 func NewBlockValidatorExecutor(opts ExecutorOptions) (*Executor, error) {
-	return NewExecutor(opts,
+	return NewExecutor(opts, false,
 		CreateIdentity{},
 		WithdrawTokens{},
 		CreateTokenAccount{},
@@ -30,7 +30,7 @@ func NewBlockValidatorExecutor(opts ExecutorOptions) (*Executor, error) {
 }
 
 func NewDirectoryExecutor(opts ExecutorOptions) (*Executor, error) {
-	return NewExecutor(opts) // TODO Add DN validators
+	return NewExecutor(opts, true) // TODO Add DN validators
 }
 
 // TxExecutor executes a specific type of transaction.

--- a/internal/chain/executor_query.go
+++ b/internal/chain/executor_query.go
@@ -39,10 +39,10 @@ func (m *Executor) queryByChainId(chainId []byte) (*query.ResponseByChainId, err
 
 	// This intentionally uses GetPersistentEntry instead of GetCurrentEntry.
 	// Callers should never see uncommitted values.
-	obj, err := m.db.GetPersistentEntry(chainId, false)
+	obj, err := m.DB.GetPersistentEntry(chainId, false)
 	// Or a transaction
 	if errors.Is(err, storage.ErrNotFound) {
-		obj, err = m.db.GetTransaction(chainId)
+		obj, err = m.DB.GetTransaction(chainId)
 	}
 	// Not a state entry or a transaction
 	if errors.Is(err, storage.ErrNotFound) {
@@ -63,7 +63,7 @@ func (m *Executor) queryByChainId(chainId []byte) (*query.ResponseByChainId, err
 }
 
 func (m *Executor) queryDirectoryByChainId(chainId []byte) (*protocol.DirectoryQueryResult, error) {
-	b, err := m.db.GetIndex(state.DirectoryIndex, chainId, "Metadata")
+	b, err := m.DB.GetIndex(state.DirectoryIndex, chainId, "Metadata")
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (m *Executor) queryDirectoryByChainId(chainId []byte) (*protocol.DirectoryQ
 	resp := new(protocol.DirectoryQueryResult)
 	resp.Entries = make([]string, md.Count)
 	for i := range resp.Entries {
-		b, err := m.db.GetIndex(state.DirectoryIndex, chainId, uint64(i))
+		b, err := m.DB.GetIndex(state.DirectoryIndex, chainId, uint64(i))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get entry %d", i)
 		}
@@ -90,19 +90,19 @@ func (m *Executor) queryByTxId(txid []byte) (*query.ResponseByTxId, error) {
 	var err error
 
 	qr := query.ResponseByTxId{}
-	qr.TxState, err = m.db.GetTx(txid)
+	qr.TxState, err = m.DB.GetTx(txid)
 	if errors.Is(err, storage.ErrNotFound) {
 		return nil, fmt.Errorf("tx %X %w", txid, storage.ErrNotFound)
 	} else if err != nil {
 		return nil, fmt.Errorf("invalid query from GetTx in state database, %v", err)
 	}
-	qr.TxPendingState, err = m.db.GetPendingTx(txid)
+	qr.TxPendingState, err = m.DB.GetPendingTx(txid)
 	if !errors.Is(err, storage.ErrNotFound) && err != nil {
 		//this is only an error if the pending states have not yet been purged or some other database error occurred
 		return nil, fmt.Errorf("%w: error in query for pending chain on txid %X", storage.ErrNotFound, txid)
 	}
 
-	qr.TxSynthTxIds, err = m.db.GetSyntheticTxIds(txid)
+	qr.TxSynthTxIds, err = m.DB.GetSyntheticTxIds(txid)
 	if !errors.Is(err, storage.ErrNotFound) && err != nil {
 		//this is only an error if the transactions produced synth tx's or some other database error occurred
 		return nil, fmt.Errorf("%w: error in query for synthetic txid txid %X", storage.ErrNotFound, txid)
@@ -138,7 +138,7 @@ func (m *Executor) Query(q *query.Query) (k, v []byte, err *protocol.Error) {
 		}
 
 		thr := query.ResponseTxHistory{}
-		txids, maxAmt, err := m.db.GetChainRange(txh.ChainId[:], txh.Start, txh.Start+txh.Limit)
+		txids, maxAmt, err := m.DB.GetChainRange(txh.ChainId[:], txh.Start, txh.Start+txh.Limit)
 		if err != nil {
 			return nil, nil, &protocol.Error{Code: protocol.CodeTxnHistory, Message: fmt.Errorf("error obtaining txid range %v", err)}
 		}

--- a/internal/chain/txn_dispatch.go
+++ b/internal/chain/txn_dispatch.go
@@ -1,0 +1,176 @@
+package chain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/internal/api/v2"
+	"github.com/AccumulateNetwork/accumulate/internal/url"
+	"github.com/AccumulateNetwork/accumulate/networks"
+	"github.com/tendermint/tendermint/rpc/client/http"
+	tm "github.com/tendermint/tendermint/types"
+	"golang.org/x/sync/errgroup"
+)
+
+type txBatch []tm.Tx
+
+// dispatcher is responsible for dispatching outgoing synthetic transactions to
+// their recipients.
+type dispatcher struct {
+	isDirectory bool
+	localIndex  int
+	local       api.ABCIBroadcastClient
+	bvn         []*http.HTTP
+	bvnBatches  []txBatch
+	dn          *http.HTTP
+	dnBatch     txBatch
+	errg        *errgroup.Group
+}
+
+// newDispatcher creates a new dispatcher.
+func newDispatcher(opts ExecutorOptions, isDirectory bool) (*dispatcher, error) {
+	d := new(dispatcher)
+	d.isDirectory = isDirectory
+	d.local = opts.Local
+	d.localIndex = -1
+	d.bvn = make([]*http.HTTP, len(opts.BlockValidators))
+	d.bvnBatches = make([]txBatch, len(opts.BlockValidators))
+
+	// If we're not a directory, make an RPC client for the DN
+	if !isDirectory && opts.Directory != "" {
+		// Parse the config entry
+		addr, err := networks.GetRpcAddr(opts.Directory)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve directory %q: %v", opts.Directory, err)
+		}
+
+		// Make the client
+		d.dn, err = http.New(addr)
+		if err != nil {
+			return nil, fmt.Errorf("could not create client for directory %q: %v", opts.Directory, err)
+		}
+	}
+
+	// Make a client for all of the BVNs
+	for i, bv := range opts.BlockValidators {
+		// Use the local client for ourself
+		if bv == "self" || bv == "local" {
+			d.localIndex = i
+			continue
+		}
+
+		// Parse the config entry
+		addr, err := networks.GetRpcAddr(bv)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve block validator %q: %v", bv, err)
+		}
+
+		// Make the client
+		d.bvn[i], err = http.New(addr)
+		if err != nil {
+			return nil, fmt.Errorf("could not create client for block validator %q: %v", bv, err)
+		}
+	}
+
+	return d, nil
+}
+
+// Reset creates new RPC client batches.
+func (d *dispatcher) Reset(ctx context.Context) {
+	d.errg = new(errgroup.Group)
+
+	d.dnBatch = d.dnBatch[:0]
+	for i, bv := range d.bvnBatches {
+		d.bvnBatches[i] = bv[:0]
+	}
+}
+
+// route gets the client for the URL
+func (d *dispatcher) route(u *url.URL) (batch *txBatch, local bool) {
+	// Is it a DN URL?
+	if dnUrl().Equal(u) {
+		if d.isDirectory {
+			return nil, true
+		}
+		if d.dn == nil {
+			panic("Directory was not configured")
+		}
+		return &d.dnBatch, false
+	}
+
+	// Is it a BVN URL?
+	if isBvnUrl(u) {
+		// For this we need some kind of lookup table that maps subnet to IP
+		panic("Cannot route BVN ADI URLs")
+	}
+
+	// Modulo routing
+	i := u.Routing() % uint64(len(d.bvn))
+	if i == uint64(d.localIndex) {
+		// Use the local client for local requests
+		return nil, true
+	}
+	return &d.bvnBatches[i], false
+}
+
+// BroadcastTxAsync dispatches the txn to the appropriate client.
+func (d *dispatcher) BroadcastTxAsync(ctx context.Context, u *url.URL, tx []byte) {
+	batch, local := d.route(u)
+	if local {
+		d.BroadcastTxAsyncLocal(ctx, tx)
+		return
+	}
+
+	*batch = append(*batch, tx)
+}
+
+// BroadcastTxAsync dispatches the txn to the appropriate client.
+func (d *dispatcher) BroadcastTxAsyncLocal(ctx context.Context, tx []byte) {
+	d.errg.Go(func() error {
+		_, err := d.local.BroadcastTxAsync(ctx, tx)
+		return err
+	})
+}
+
+func (d *dispatcher) send(ctx context.Context, client *http.HTTP, batch txBatch) {
+	switch len(batch) {
+	case 0:
+		// Nothing to do
+
+	case 1:
+		// Send single. Tendermint's batch RPC client is buggy - it breaks if
+		// you don't give it more than one request.
+		d.errg.Go(func() error {
+			_, err := client.BroadcastTxAsync(ctx, batch[0])
+			return err
+		})
+
+	default:
+		// Send batch
+		d.errg.Go(func() error {
+			b := client.NewBatch()
+			for _, tx := range batch {
+				_, err := b.BroadcastTxAsync(ctx, tx)
+				if err != nil {
+					return err
+				}
+			}
+			_, err := b.Send(ctx)
+			return err
+		})
+	}
+}
+
+// Send sends all of the batches.
+func (d *dispatcher) Send(ctx context.Context) error {
+	// Send to the DN
+	d.send(ctx, d.dn, d.dnBatch)
+
+	// Send to the BVNs
+	for i := range d.bvn {
+		d.send(ctx, d.bvn[i], d.bvnBatches[i])
+	}
+
+	// Wait for everyone to finish
+	return d.errg.Wait()
+}

--- a/internal/chain/utils.go
+++ b/internal/chain/utils.go
@@ -1,0 +1,19 @@
+package chain
+
+import (
+	"strings"
+
+	"github.com/AccumulateNetwork/accumulate/internal/url"
+)
+
+func dnUrl() *url.URL {
+	return &url.URL{Authority: "dn"}
+}
+
+func bvnUrl(subnet string) *url.URL {
+	return &url.URL{Authority: "bvn-" + subnet}
+}
+
+func isBvnUrl(u *url.URL) bool {
+	return u.Path == "" && strings.HasPrefix(u.Authority, "bvn-")
+}

--- a/internal/logging/test.go
+++ b/internal/logging/test.go
@@ -26,23 +26,25 @@ func (l *TestLogger) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func NewTestZeroLogger(t testing.TB, format string) zerolog.Logger {
-	var w io.Writer = &TestLogger{Test: t}
-	switch strings.ToLower(format) {
-	case log.LogFormatPlain, log.LogFormatText:
-		w = newConsoleWriter(w)
+func TestLogWriter(t testing.TB) func(string) io.Writer {
+	return func(format string) io.Writer {
+		var w io.Writer = &TestLogger{Test: t}
+		switch strings.ToLower(format) {
+		case log.LogFormatPlain, log.LogFormatText:
+			w = newConsoleWriter(w)
 
-	case log.LogFormatJSON:
+		case log.LogFormatJSON:
 
-	default:
-		t.Fatalf("Unsupported log format: %s", format)
+		default:
+			t.Fatalf("Unsupported log format: %s", format)
+		}
+
+		return w
 	}
-
-	return zerolog.New(w)
 }
 
 func ExcludeMessages(messages ...string) zerolog.HookFunc {
-	return func(e *zerolog.Event, level zerolog.Level, message string) {
+	return func(e *zerolog.Event, _ zerolog.Level, message string) {
 		for _, m := range messages {
 			if m == message {
 				e.Discard()

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -103,7 +103,7 @@ func (n *Node) waitForGRPC() coregrpc.BroadcastAPIClient {
 
 func (n *Node) waitForRPC() error {
 	for _, bvc := range n.Config.Accumulate.Networks {
-		addr, err := networks.GetRpcAddr(bvc, networks.TmRpcPortOffset)
+		addr, err := networks.GetRpcAddr(bvc)
 		if err != nil {
 			return err
 		}

--- a/internal/relay/helper.go
+++ b/internal/relay/helper.go
@@ -8,7 +8,7 @@ import (
 func NewClients(targetList ...string) ([]Client, error) {
 	clients := []Client{}
 	for _, nameOrIP := range targetList {
-		addr, err := networks.GetRpcAddr(nameOrIP, networks.TmRpcPortOffset)
+		addr, err := networks.GetRpcAddr(nameOrIP)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/testing/tx.go
+++ b/internal/testing/tx.go
@@ -1,0 +1,68 @@
+package testing
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/AccumulateNetwork/accumulate/internal/api"
+	apitypes "github.com/AccumulateNetwork/accumulate/types/api"
+	querytypes "github.com/AccumulateNetwork/accumulate/types/api/query"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+func WaitForTxV1(query *api.Query, txResp *apitypes.APIDataResponse) error {
+	var data struct{ Txid string }
+	err := json.Unmarshal(*txResp.Data, &data)
+	if err != nil {
+		return err
+	}
+
+	txid, err := hex.DecodeString(data.Txid)
+	if err != nil {
+		return err
+	}
+
+	return WaitForTxidV1(query, txid)
+}
+
+func WaitForTxidV1(query *api.Query, txid []byte) error {
+	var resp *coretypes.ResultABCIQuery
+	var err error
+	for {
+		resp, err = query.QueryByTxId(txid)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			return err
+		}
+		time.Sleep(time.Second / 10)
+	}
+	if resp.Response.Code != 0 {
+		return fmt.Errorf("query failed with code %d: %s", resp.Response.Code, resp.Response.Info)
+	}
+
+	res := new(querytypes.ResponseByTxId)
+	err = res.UnmarshalBinary(resp.Response.Value)
+	if err != nil {
+		return fmt.Errorf("invalid TX response: %v", err)
+	}
+
+	if len(res.TxSynthTxIds)%32 != 0 {
+		panic("bad synth IDs")
+	}
+
+	count := len(res.TxSynthTxIds) / 32
+	for i := 0; i < count; i++ {
+		id := res.TxSynthTxIds[i*32 : (i+1)*32]
+		err = WaitForTxidV1(query, id)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/networks/get.go
+++ b/networks/get.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 )
 
-func GetRpcAddr(netOrIp string, portOffset int) (string, error) {
+func GetRpcAddr(netOrIp string) (string, error) {
 	net := all[netOrIp]
 	ip, err := url.Parse(netOrIp)
 	if net != nil {
-		ip = &url.URL{Scheme: "tcp", Host: fmt.Sprintf("%s:%d", net.Nodes[0].IP, net.Port+portOffset)}
+		ip = &url.URL{Scheme: "tcp", Host: fmt.Sprintf("%s:%d", net.Nodes[0].IP, net.Port+TmRpcPortOffset)}
 	} else if err != nil {
 		return "", fmt.Errorf("%q is not a URL or a named network", netOrIp)
 	} else if ip.Port() == "" {


### PR DESCRIPTION
Creates a new transaction dispatcher. The new dispatcher:
- Uses batch RPC calls, so all synthetic transactions are still broadcast in a single request.
- Uses a local RPC client for synthetic transactions destined for the local node, which does not create a network connection.
- Knows how to route system records such as `acc://dn` or `acc://bvn-...` directly to the correct network, circumventing the normal routing method.

With this change, the relay is no longer used outside of the API and can be removed once API v1 is removed.

Updates `accumulated init devnet` to support creating a multi-BVN devnet.

No functional changes. To verify, create a multi-BVN devnet, run it, and make sure the normal things work.