### PR TITLE
BVN anchor → DN

### DIFF
--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -23,6 +23,7 @@ func NewBlockValidatorExecutor(opts ExecutorOptions) (*Executor, error) {
 		SyntheticTokenDeposit{},
 		SyntheticDepositCredits{},
 		SyntheticSignTransactions{},
+		SyntheticAnchor{IsDirectory: false},
 
 		// TODO Only for TestNet
 		AcmeFaucet{},
@@ -30,7 +31,9 @@ func NewBlockValidatorExecutor(opts ExecutorOptions) (*Executor, error) {
 }
 
 func NewDirectoryExecutor(opts ExecutorOptions) (*Executor, error) {
-	return NewExecutor(opts, true) // TODO Add DN validators
+	return NewExecutor(opts, true,
+		SyntheticAnchor{IsDirectory: true},
+	)
 }
 
 // TxExecutor executes a specific type of transaction.

--- a/internal/chain/executor_synthetic.go
+++ b/internal/chain/executor_synthetic.go
@@ -1,0 +1,347 @@
+package chain
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding"
+	"errors"
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/internal/abci"
+	"github.com/AccumulateNetwork/accumulate/internal/logging"
+	"github.com/AccumulateNetwork/accumulate/internal/url"
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/smt/common"
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulate/types/state"
+)
+
+// synthCount returns the number of synthetic transactions sent by this subnet.
+func (m *Executor) synthCount() (uint64, error) {
+	k := storage.ComputeKey("SyntheticTransactionCount")
+	b, err := m.dbTx.Read(k)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return 0, err
+	}
+
+	var n uint64
+	if len(b) > 0 {
+		n, _ = common.BytesUint64(b)
+	}
+	return n, nil
+}
+
+// nextSynthCount returns and increments the number of synthetic transactions
+// sent by this subnet.
+func (m *Executor) nextSynthCount() (uint64, error) {
+	// TODO Replace this with the actual key nonce
+
+	n, err := m.synthCount()
+	if err != nil {
+		return 0, err
+	}
+	n++
+
+	k := storage.ComputeKey("SyntheticTransactionCount")
+	m.dbTx.Write(k, common.Uint64Bytes(n))
+	return n, nil
+}
+
+// addSynthTxns prepares synthetic transactions for signing next block.
+func (m *Executor) addSynthTxns(parentTxId types.Bytes, st *StateManager) error {
+	// Need to pass this to a threaded batcher / dispatcher to do both signing
+	// and sending of synth tx. No need to spend valuable time here doing that.
+	for _, sub := range st.submissions {
+		// Generate a synthetic tx and send to the router. Need to track txid to
+		// make sure they get processed.
+
+		tx, err := m.buildSynthTxn(parentTxId, sub.url, sub.body)
+		if err != nil {
+			return err
+		}
+
+		txSynthetic := state.NewPendingTransaction(tx)
+		txSyntheticObject := new(state.Object)
+		synthTxData, err := txSynthetic.MarshalBinary()
+		if err != nil {
+			return err
+		}
+
+		txSyntheticObject.Entry = synthTxData
+		m.dbTx.AddSynthTx(parentTxId, tx.TransactionHash(), txSyntheticObject)
+	}
+
+	return nil
+}
+
+func (m *Executor) addAnchorTxn(height int64) ([][]byte, error) {
+	srcUrl, err := nodeUrl(m.DB, m.isDirectory)
+	if err != nil {
+		return nil, err
+	}
+
+	synth, err := m.DB.SynthTxidChain()
+	if err != nil {
+		return nil, err
+	}
+
+	synthHead, err := synth.Record()
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return nil, err
+	}
+
+	anchor, err := m.DB.MinorAnchorChain()
+	if err != nil {
+		return nil, err
+	}
+
+	anchorHead, err := anchor.Record()
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case anchorHead.Index == height-1 && len(anchorHead.Chains) > 0:
+		// Modified chains last block, continue
+	case synthHead.Index == height-1:
+		// Produced synthetic transactions last block, continue
+	default:
+		// Nothing happened last block, so skip creating an anchor txn
+		return nil, nil
+	}
+
+	body := new(protocol.SyntheticAnchor)
+	body.Source = srcUrl.String()
+	body.Index = m.height
+	body.Timestamp = m.time
+	copy(body.Root[:], m.DB.RootHash())
+	body.Chains = anchorHead.Chains
+	copy(body.ChainAnchor[:], anchor.Chain.Anchor())
+	copy(body.SynthTxnAnchor[:], synth.Chain.Anchor())
+
+	m.logger.Debug("Creating anchor txn", "root", logging.AsHex(body.Root), "chains", logging.AsHex(body.ChainAnchor), "synth", logging.AsHex(body.SynthTxnAnchor))
+
+	var txns []*transactions.GenTransaction
+	switch {
+	case m.isDirectory:
+		// TODO Send anchors from DN to all BVNs
+
+	case m.Directory != "":
+		// Send anchor from BVN to DN
+		tx, err := m.buildSynthTxn(make([]byte, 32), dnUrl(), body)
+		if err != nil {
+			return nil, err
+		}
+		txns = append(txns, tx)
+
+	default:
+		// If the Directory is not specified, do not send the anchor TXN
+	}
+
+	var txids [][]byte
+	for _, tx := range txns {
+		obj := new(state.Object)
+		obj.Entry, err = state.NewPendingTransaction(tx).MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		err = m.dbTx.WriteSynthTxn(tx.TransactionHash(), obj)
+		if err != nil {
+			return nil, err
+		}
+
+		txids = append(txids, tx.TransactionHash())
+	}
+
+	return txids, nil
+}
+
+func (m *Executor) buildSynthTxn(parentTxid []byte, dest *url.URL, body encoding.BinaryMarshaler) (*transactions.GenTransaction, error) {
+	data, err := body.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal synthetic transaction payload: %v", err)
+	}
+
+	tx := new(transactions.GenTransaction)
+	tx.SigInfo = new(transactions.SignatureInfo)
+	tx.SigInfo.URL = dest.String()
+	tx.SigInfo.KeyPageHeight = 1
+	tx.SigInfo.KeyPageIndex = 0
+	tx.Transaction = data
+
+	tx.SigInfo.KeyPageHeight = 1
+	tx.SigInfo.Nonce, err = m.nextSynthCount()
+	if err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+// signSynthTxns signs synthetic transactions from the previous block and
+// prepares them to be sent next block.
+func (m *Executor) signSynthTxns(txns [][]byte) error {
+	// TODO If the leader fails, will the block happen again or will Tendermint
+	// move to the next block? We need to be sure that synthetic transactions
+	// won't get lost.
+
+	// Load the synth txid chain
+	chain, err := m.DB.SynthTxidChain()
+	if err != nil {
+		return err
+	}
+
+	// Retrieve transactions from the previous block
+	prevBlockTxns, err := chain.LastBlock(m.height - 1)
+	if err != nil {
+		return err
+	}
+
+	// Transactions from the block were signed first
+	txns = append(prevBlockTxns, txns...)
+
+	// Only proceed if we have transactions to sign
+	if len(txns) == 0 {
+		return nil
+	}
+
+	// Use the synthetic transaction count to calculate what the nonces were
+	nonce, err := m.synthCount()
+	if err != nil {
+		return err
+	}
+
+	// Sign all of the transactions
+	body := new(protocol.SyntheticSignTransactions)
+	for i, txid := range txns {
+		m.logger.Debug("Signing synth txn", "txid", logging.AsHex(txid))
+
+		// For each pending synthetic transaction
+		var synthSig protocol.SyntheticSignature
+		copy(synthSig.Txid[:], txid)
+
+		// The nonce must be the final nonce minus (I + 1)
+		synthSig.Nonce = nonce - 1 - uint64(i)
+
+		// Sign it
+		ed := new(transactions.ED25519Sig)
+		ed.PublicKey = m.Key[32:]
+		err = ed.Sign(synthSig.Nonce, m.Key, txid[:])
+		if err != nil {
+			return err
+		}
+
+		// Add it to the list
+		synthSig.Signature = ed.Signature
+		body.Transactions = append(body.Transactions, synthSig)
+	}
+
+	// Construct the signature transaction
+	tx := new(transactions.GenTransaction)
+	tx.SigInfo = new(transactions.SignatureInfo)
+	tx.SigInfo.URL = protocol.ACME
+	tx.SigInfo.KeyPageIndex = 0
+	tx.Transaction, err = body.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	tx.SigInfo.KeyPageHeight = 1
+	tx.SigInfo.Nonce, err = m.nextSynthCount()
+	if err != nil {
+		return err
+	}
+
+	// Sign it
+	ed := new(transactions.ED25519Sig)
+	tx.Signature = append(tx.Signature, ed)
+	ed.PublicKey = m.Key[32:]
+	err = ed.Sign(tx.SigInfo.Nonce, m.Key, tx.TransactionHash())
+	if err != nil {
+		return err
+	}
+
+	// Marshal it
+	data, err := tx.Marshal()
+	if err != nil {
+		return err
+	}
+
+	// Send it
+	go m.Local.BroadcastTxAsync(context.Background(), data)
+	return nil
+}
+
+// sendSynthTxns sends signed synthetic transactions from previous blocks.
+func (m *Executor) sendSynthTxns() ([]abci.SynthTxnReference, error) {
+	// Get the signatures from the last block
+	sigs, err := m.DB.GetSynthTxnSigs()
+	if err != nil {
+		return nil, err
+	}
+
+	// Is there anything to send?
+	if len(sigs) == 0 {
+		return nil, nil
+	}
+
+	// Array for synth TXN references
+	refs := make([]abci.SynthTxnReference, 0, len(sigs))
+
+	// Process all the transactions
+	for _, sig := range sigs {
+		// Load the pending transaction object
+		obj, err := m.DB.GetSynthTxn(sig.Txid)
+		if err != nil {
+			return nil, err
+		}
+
+		// Unmarshal it
+		state := new(state.PendingTransaction)
+		err = obj.As(state)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert it back to a transaction
+		tx := state.Restore()
+
+		// Add the signature
+		tx.Signature = append(tx.Signature, &transactions.ED25519Sig{
+			Nonce:     sig.Nonce,
+			PublicKey: sig.PublicKey,
+			Signature: sig.Signature,
+		})
+
+		// Marshal the transaction
+		raw, err := tx.Marshal()
+		if err != nil {
+			return nil, err
+		}
+
+		// Parse the URL
+		u, err := url.Parse(tx.SigInfo.URL)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add it to the batch
+		m.logger.Debug("Sending synth txn", "actor", u.String(), "txid", logging.AsHex(tx.TransactionHash()))
+		m.dispatcher.BroadcastTxAsync(context.Background(), u, raw)
+
+		// Delete the signature
+		m.dbTx.DeleteSynthTxnSig(sig.Txid)
+
+		// Add the synthetic transaction reference
+		var ref abci.SynthTxnReference
+		ref.Type = uint64(tx.TransactionType())
+		ref.Url = tx.SigInfo.URL
+		ref.TxRef = sha256.Sum256(raw)
+		copy(ref.Hash[:], tx.TransactionHash())
+		refs = append(refs, ref)
+	}
+
+	return refs, nil
+}

--- a/internal/chain/synthetic_anchor.go
+++ b/internal/chain/synthetic_anchor.go
@@ -1,0 +1,60 @@
+package chain
+
+import (
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+	"github.com/AccumulateNetwork/accumulate/types/state"
+)
+
+type SyntheticAnchor struct {
+	IsDirectory bool
+}
+
+func (SyntheticAnchor) Type() types.TxType { return types.TxTypeSyntheticAnchor }
+
+func (x SyntheticAnchor) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	nodeUrl, err := nodeUrl(st.dbTx.DB(), x.IsDirectory)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve subnet ID: %v", err)
+	}
+
+	// Verify that the sponsor is the node
+	if !st.SponsorUrl.Equal(nodeUrl) {
+		return fmt.Errorf("invalid sponsor: %q != %q", st.SponsorUrl, nodeUrl)
+	}
+
+	// Unpack the payload
+	body := new(protocol.SyntheticAnchor)
+	err = tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	// TODO Enable once mirroring has been implemented
+	if false {
+		// Load the source's record
+		source, err := st.LoadString(body.Source)
+		if err != nil {
+			return fmt.Errorf("invalid source %q: %v", body.Source, err)
+		}
+
+		// Check that the source is an ADI
+		if source.Header().Type != types.ChainTypeIdentity {
+			return fmt.Errorf("invalid source %q: want chain type %v, got %v", body.Source, types.ChainTypeIdentity, source.Header().Type)
+		}
+	}
+
+	chain := new(state.Anchor)
+	chain.ChainUrl = types.String(nodeUrl.JoinPath(anchorChainName(x.IsDirectory, body.Major)).String())
+	chain.Index = body.Index
+	chain.Timestamp = body.Timestamp
+	chain.Root = body.Root
+	chain.ChainAnchor = body.ChainAnchor
+	chain.Synthetic = body.SynthTxnAnchor
+	chain.Chains = body.Chains
+	st.Update(chain)
+	return nil
+}

--- a/internal/chain/utils.go
+++ b/internal/chain/utils.go
@@ -1,9 +1,11 @@
 package chain
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/AccumulateNetwork/accumulate/internal/url"
+	"github.com/AccumulateNetwork/accumulate/types/state"
 )
 
 func dnUrl() *url.URL {
@@ -16,4 +18,34 @@ func bvnUrl(subnet string) *url.URL {
 
 func isBvnUrl(u *url.URL) bool {
 	return u.Path == "" && strings.HasPrefix(u.Authority, "bvn-")
+}
+
+func nodeUrl(db *state.StateDB, dir bool) (*url.URL, error) {
+	if dir {
+		return dnUrl(), nil
+	}
+
+	subnet, err := db.SubnetID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve subnet ID: %v", err)
+	}
+	return bvnUrl(subnet), nil
+}
+
+func anchorChainName(dir, major bool) string {
+	parts := []string{"", "", "anchor", "pool"}
+
+	if dir {
+		parts[0] = "bvn"
+	} else {
+		parts[0] = "dn"
+	}
+
+	if major {
+		parts[1] = "major"
+	} else {
+		parts[1] = "minor"
+	}
+
+	return strings.Join(parts, "-")
 }

--- a/internal/testing/app_client.go
+++ b/internal/testing/app_client.go
@@ -178,8 +178,7 @@ func (c *ABCIApplicationClient) addSynthTxns(blockIndex int64) {
 		return
 	}
 
-	head := new(state.SyntheticTransactionChain)
-	err = chain.RecordAs(head)
+	head, err := chain.Record()
 	if errors.Is(err, storage.ErrNotFound) {
 		// Nothing to do
 		return
@@ -198,7 +197,7 @@ func (c *ABCIApplicationClient) addSynthTxns(blockIndex int64) {
 
 	// Pull the transaction IDs from the anchor chain
 	height := chain.Height()
-	txns, err := chain.Entries(height-head.Count, height)
+	txns, err := chain.Chain.Entries(height-head.Count, height)
 	if err != nil {
 		c.onError(err)
 		return

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -306,3 +306,24 @@ SyntheticSignature:
       type: bytes
     - name: Nonce
       type: uvarint
+
+SyntheticAnchor:
+  kind: tx
+  fields:
+    - name: Source
+      type: string
+      is-url: true
+    - name: Major
+      type: bool
+    - name: Index
+      type: varint
+    - name: Timestamp
+      type: time
+    - name: Root
+      type: chain
+    - name: SynthTxnAnchor
+      type: chain
+    - name: ChainAnchor
+      type: chain
+    - name: Chains
+      type: chainSet

--- a/protocol/types_gen.go
+++ b/protocol/types_gen.go
@@ -122,6 +122,17 @@ type MetricsResponse struct {
 	Value interface{} `json:"value,omitempty" form:"value" query:"value" validate:"required"`
 }
 
+type SyntheticAnchor struct {
+	Source         string     `json:"source,omitempty" form:"source" query:"source" validate:"required,acc-url"`
+	Major          bool       `json:"major,omitempty" form:"major" query:"major" validate:"required"`
+	Index          int64      `json:"index,omitempty" form:"index" query:"index" validate:"required"`
+	Timestamp      time.Time  `json:"timestamp,omitempty" form:"timestamp" query:"timestamp" validate:"required"`
+	Root           [32]byte   `json:"root,omitempty" form:"root" query:"root" validate:"required"`
+	SynthTxnAnchor [32]byte   `json:"synthTxnAnchor,omitempty" form:"synthTxnAnchor" query:"synthTxnAnchor" validate:"required"`
+	ChainAnchor    [32]byte   `json:"chainAnchor,omitempty" form:"chainAnchor" query:"chainAnchor" validate:"required"`
+	Chains         [][32]byte `json:"chains,omitempty" form:"chains" query:"chains" validate:"required"`
+}
+
 type SyntheticBurnTokens struct {
 	Amount big.Int `json:"amount,omitempty" form:"amount" query:"amount" validate:"required"`
 }
@@ -234,6 +245,8 @@ func (*CreateToken) GetType() types.TransactionType { return types.TxTypeCreateT
 func (*IdentityCreate) GetType() types.TransactionType { return types.TxTypeCreateIdentity }
 
 func (*IssueTokens) GetType() types.TransactionType { return types.TxTypeIssueTokens }
+
+func (*SyntheticAnchor) GetType() types.TransactionType { return types.TxTypeSyntheticAnchor }
 
 func (*SyntheticBurnTokens) GetType() types.TransactionType { return types.TxTypeSyntheticBurnTokens }
 
@@ -554,6 +567,48 @@ func (v *MetricsRequest) Equal(u *MetricsRequest) bool {
 
 	if !(v.Duration == u.Duration) {
 		return false
+	}
+
+	return true
+}
+
+func (v *SyntheticAnchor) Equal(u *SyntheticAnchor) bool {
+	if !(v.Source == u.Source) {
+		return false
+	}
+
+	if !(v.Major == u.Major) {
+		return false
+	}
+
+	if !(v.Index == u.Index) {
+		return false
+	}
+
+	if !(v.Timestamp == u.Timestamp) {
+		return false
+	}
+
+	if !(v.Root == u.Root) {
+		return false
+	}
+
+	if !(v.SynthTxnAnchor == u.SynthTxnAnchor) {
+		return false
+	}
+
+	if !(v.ChainAnchor == u.ChainAnchor) {
+		return false
+	}
+
+	if !(len(v.Chains) == len(u.Chains)) {
+		return false
+	}
+
+	for i := range v.Chains {
+		if v.Chains[i] != u.Chains[i] {
+			return false
+		}
 	}
 
 	return true
@@ -973,6 +1028,30 @@ func (v *MetricsRequest) BinarySize() int {
 	n += encoding.StringBinarySize(v.Metric)
 
 	n += encoding.DurationBinarySize(v.Duration)
+
+	return n
+}
+
+func (v *SyntheticAnchor) BinarySize() int {
+	var n int
+
+	n += encoding.UvarintBinarySize(types.TxTypeSyntheticAnchor.ID())
+
+	n += encoding.StringBinarySize(v.Source)
+
+	n += encoding.BoolBinarySize(v.Major)
+
+	n += encoding.VarintBinarySize(v.Index)
+
+	n += encoding.TimeBinarySize(v.Timestamp)
+
+	n += encoding.ChainBinarySize(&v.Root)
+
+	n += encoding.ChainBinarySize(&v.SynthTxnAnchor)
+
+	n += encoding.ChainBinarySize(&v.ChainAnchor)
+
+	n += encoding.ChainSetBinarySize(v.Chains)
 
 	return n
 }
@@ -1412,6 +1491,30 @@ func (v *MetricsRequest) MarshalBinary() ([]byte, error) {
 	buffer.Write(encoding.StringMarshalBinary(v.Metric))
 
 	buffer.Write(encoding.DurationMarshalBinary(v.Duration))
+
+	return buffer.Bytes(), nil
+}
+
+func (v *SyntheticAnchor) MarshalBinary() ([]byte, error) {
+	var buffer bytes.Buffer
+
+	buffer.Write(encoding.UvarintMarshalBinary(types.TxTypeSyntheticAnchor.ID()))
+
+	buffer.Write(encoding.StringMarshalBinary(v.Source))
+
+	buffer.Write(encoding.BoolMarshalBinary(v.Major))
+
+	buffer.Write(encoding.VarintMarshalBinary(v.Index))
+
+	buffer.Write(encoding.TimeMarshalBinary(v.Timestamp))
+
+	buffer.Write(encoding.ChainMarshalBinary(&v.Root))
+
+	buffer.Write(encoding.ChainMarshalBinary(&v.SynthTxnAnchor))
+
+	buffer.Write(encoding.ChainMarshalBinary(&v.ChainAnchor))
+
+	buffer.Write(encoding.ChainSetMarshalBinary(v.Chains))
 
 	return buffer.Bytes(), nil
 }
@@ -2095,6 +2198,74 @@ func (v *MetricsRequest) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+func (v *SyntheticAnchor) UnmarshalBinary(data []byte) error {
+	typ := types.TxTypeSyntheticAnchor
+	if v, err := encoding.UvarintUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding TX type: %w", err)
+	} else if v != uint64(typ) {
+		return fmt.Errorf("invalid TX type: want %v, got %v", typ, types.TransactionType(v))
+	}
+	data = data[encoding.UvarintBinarySize(uint64(typ)):]
+
+	if x, err := encoding.StringUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Source: %w", err)
+	} else {
+		v.Source = x
+	}
+	data = data[encoding.StringBinarySize(v.Source):]
+
+	if x, err := encoding.BoolUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Major: %w", err)
+	} else {
+		v.Major = x
+	}
+	data = data[encoding.BoolBinarySize(v.Major):]
+
+	if x, err := encoding.VarintUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Index: %w", err)
+	} else {
+		v.Index = x
+	}
+	data = data[encoding.VarintBinarySize(v.Index):]
+
+	if x, err := encoding.TimeUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Timestamp: %w", err)
+	} else {
+		v.Timestamp = x
+	}
+	data = data[encoding.TimeBinarySize(v.Timestamp):]
+
+	if x, err := encoding.ChainUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Root: %w", err)
+	} else {
+		v.Root = x
+	}
+	data = data[encoding.ChainBinarySize(&v.Root):]
+
+	if x, err := encoding.ChainUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding SynthTxnAnchor: %w", err)
+	} else {
+		v.SynthTxnAnchor = x
+	}
+	data = data[encoding.ChainBinarySize(&v.SynthTxnAnchor):]
+
+	if x, err := encoding.ChainUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding ChainAnchor: %w", err)
+	} else {
+		v.ChainAnchor = x
+	}
+	data = data[encoding.ChainBinarySize(&v.ChainAnchor):]
+
+	if x, err := encoding.ChainSetUnmarshalBinary(data); err != nil {
+		return fmt.Errorf("error decoding Chains: %w", err)
+	} else {
+		v.Chains = x
+	}
+	data = data[encoding.ChainSetBinarySize(v.Chains):]
+
+	return nil
+}
+
 func (v *SyntheticBurnTokens) UnmarshalBinary(data []byte) error {
 	typ := types.TxTypeSyntheticBurnTokens
 	if v, err := encoding.UvarintUnmarshalBinary(data); err != nil {
@@ -2495,6 +2666,28 @@ func (v *MetricsRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&u)
 }
 
+func (v *SyntheticAnchor) MarshalJSON() ([]byte, error) {
+	u := struct {
+		Source         string    `json:"source,omitempty"`
+		Major          bool      `json:"major,omitempty"`
+		Index          int64     `json:"index,omitempty"`
+		Timestamp      time.Time `json:"timestamp,omitempty"`
+		Root           string    `json:"root,omitempty"`
+		SynthTxnAnchor string    `json:"synthTxnAnchor,omitempty"`
+		ChainAnchor    string    `json:"chainAnchor,omitempty"`
+		Chains         []string  `json:"chains,omitempty"`
+	}{}
+	u.Source = v.Source
+	u.Major = v.Major
+	u.Index = v.Index
+	u.Timestamp = v.Timestamp
+	u.Root = encoding.ChainToJSON(v.Root)
+	u.SynthTxnAnchor = encoding.ChainToJSON(v.SynthTxnAnchor)
+	u.ChainAnchor = encoding.ChainToJSON(v.ChainAnchor)
+	u.Chains = encoding.ChainSetToJSON(v.Chains)
+	return json.Marshal(&u)
+}
+
 func (v *SyntheticCreateChain) MarshalJSON() ([]byte, error) {
 	u := struct {
 		Cause  string        `json:"cause,omitempty"`
@@ -2735,6 +2928,55 @@ func (v *MetricsRequest) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("error decoding Duration: %w", err)
 	} else {
 		v.Duration = x
+	}
+	return nil
+}
+
+func (v *SyntheticAnchor) UnmarshalJSON(data []byte) error {
+	u := struct {
+		Source         string    `json:"source,omitempty"`
+		Major          bool      `json:"major,omitempty"`
+		Index          int64     `json:"index,omitempty"`
+		Timestamp      time.Time `json:"timestamp,omitempty"`
+		Root           string    `json:"root,omitempty"`
+		SynthTxnAnchor string    `json:"synthTxnAnchor,omitempty"`
+		ChainAnchor    string    `json:"chainAnchor,omitempty"`
+		Chains         []string  `json:"chains,omitempty"`
+	}{}
+	u.Source = v.Source
+	u.Major = v.Major
+	u.Index = v.Index
+	u.Timestamp = v.Timestamp
+	u.Root = encoding.ChainToJSON(v.Root)
+	u.SynthTxnAnchor = encoding.ChainToJSON(v.SynthTxnAnchor)
+	u.ChainAnchor = encoding.ChainToJSON(v.ChainAnchor)
+	u.Chains = encoding.ChainSetToJSON(v.Chains)
+	if err := json.Unmarshal(data, &u); err != nil {
+		return err
+	}
+	v.Source = u.Source
+	v.Major = u.Major
+	v.Index = u.Index
+	v.Timestamp = u.Timestamp
+	if x, err := encoding.ChainFromJSON(u.Root); err != nil {
+		return fmt.Errorf("error decoding Root: %w", err)
+	} else {
+		v.Root = x
+	}
+	if x, err := encoding.ChainFromJSON(u.SynthTxnAnchor); err != nil {
+		return fmt.Errorf("error decoding SynthTxnAnchor: %w", err)
+	} else {
+		v.SynthTxnAnchor = x
+	}
+	if x, err := encoding.ChainFromJSON(u.ChainAnchor); err != nil {
+		return fmt.Errorf("error decoding ChainAnchor: %w", err)
+	} else {
+		v.ChainAnchor = x
+	}
+	if x, err := encoding.ChainSetFromJSON(u.Chains); err != nil {
+		return fmt.Errorf("error decoding Chains: %w", err)
+	} else {
+		v.Chains = x
 	}
 	return nil
 }

--- a/types/state/anchor_chain.go
+++ b/types/state/anchor_chain.go
@@ -19,9 +19,9 @@ func (ac *AnchorChainManager) Height() int64 {
 }
 
 func (ac *AnchorChainManager) Record() (*Anchor, error) {
-	anchor := new(Anchor)
-	err := ac.Chain.RecordAs(anchor)
-	return anchor, err
+	record := new(Anchor)
+	err := ac.Chain.RecordAs(record)
+	return record, err
 }
 
 func (ac *AnchorChainManager) Update(index int64, timestamp time.Time, chains [][32]byte) error {

--- a/types/state/index.go
+++ b/types/state/index.go
@@ -34,18 +34,18 @@ func (db *StateDB) Read(key storage.Key) ([]byte, error) {
 
 func (tx *DBTransaction) WriteIndex(index Index, chain []byte, key interface{}, value []byte) {
 	k := storage.ComputeKey(string(index), chain, key)
-	tx.state.logInfo("WriteIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "value", hex.EncodeToString(value), "computed", hex.EncodeToString(k[:]))
+	tx.state.logDebug("WriteIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "value", hex.EncodeToString(value), "computed", hex.EncodeToString(k[:]))
 	tx.Write(k, value)
 }
 
 func (tx *DBTransaction) GetIndex(index Index, chain []byte, key interface{}) ([]byte, error) {
 	k := storage.ComputeKey(string(index), chain, key)
-	tx.state.logInfo("GetIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "computed", hex.EncodeToString(k[:]))
+	tx.state.logDebug("GetIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "computed", hex.EncodeToString(k[:]))
 	return tx.Read(k)
 }
 
 func (db *StateDB) GetIndex(index Index, chain []byte, key interface{}) ([]byte, error) {
 	k := storage.ComputeKey(string(index), chain, key)
-	db.logInfo("GetIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "computed", hex.EncodeToString(k[:]))
+	db.logDebug("GetIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "computed", hex.EncodeToString(k[:]))
 	return db.Read(k)
 }

--- a/types/state/stateTxn.go
+++ b/types/state/stateTxn.go
@@ -29,6 +29,8 @@ func (s *StateDB) Begin() *DBTransaction {
 // DB returns the transaction's database.
 func (tx *DBTransaction) DB() *StateDB { return tx.state }
 
+func (tx *DBTransaction) Dirty() bool { return true }
+
 func (tx *DBTransaction) AddSynthTxnSig(sig *SyntheticSignature) {
 	tx.dirty = true
 	tx.addSynthSigs = append(tx.addSynthSigs, sig)

--- a/types/state/synth_chain.go
+++ b/types/state/synth_chain.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
+)
+
+type SynthChainManager struct {
+	Chain ChainManager
+}
+
+func (sc *SynthChainManager) Height() int64 {
+	return sc.Chain.Height()
+}
+
+func (sc *SynthChainManager) Record() (*SyntheticTransactionChain, error) {
+	record := new(SyntheticTransactionChain)
+	err := sc.Chain.RecordAs(record)
+	return record, err
+}
+
+func (sc *SynthChainManager) Update(index int64, txids [][32]byte) error {
+	// Do we have something to do?
+	if len(txids) == 0 {
+		return nil
+	}
+
+	// Sort the txn IDs
+	sort.Slice(txids, func(i, j int) bool {
+		return bytes.Compare(txids[i][:], txids[j][:]) < 0
+	})
+
+	// Add all of the synth txids
+	for _, txid := range txids {
+		err := sc.Chain.AddEntry(txid[:])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Update the record
+	return sc.Chain.UpdateAs(&SyntheticTransactionChain{
+		Index: index,
+		Count: int64(len(txids)),
+	})
+}
+
+// LastBlock returns entries from the last block
+func (sc *SynthChainManager) LastBlock(blockIndex int64) ([][]byte, error) {
+	head, err := sc.Record()
+	if errors.Is(err, storage.ErrNotFound) {
+		// Nothing to do
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	if head.Index != blockIndex {
+		// Nothing happened last block
+		return nil, nil
+	}
+
+	height := sc.Height()
+	return sc.Chain.Entries(height-head.Count, height)
+}

--- a/types/state/types.yml
+++ b/types/state/types.yml
@@ -26,8 +26,14 @@ Anchor:
       type: varint
     - name: Timestamp
       type: time
+    - name: Root
+      type: chain
     - name: Chains
       type: chainSet
+    - name: ChainAnchor
+      type: chain
+    - name: Synthetic
+      type: chain
 
 SyntheticSignature:
   fields:

--- a/types/transaction_types.go
+++ b/types/transaction_types.go
@@ -98,6 +98,9 @@ const (
 	// TxTypeSyntheticDepositTokens deposits tokens into token accounts.
 	TxTypeSyntheticDepositTokens TransactionType = 0x33
 
+	// TxTypeSyntheticAnchor anchors one network to another.
+	TxTypeSyntheticAnchor TransactionType = 0x34
+
 	// TxTypeSyntheticDepositCredits deposits credits into a credit holder.
 	TxTypeSyntheticDepositCredits TransactionType = 0x35
 
@@ -156,6 +159,8 @@ func (t TransactionType) String() string {
 		return "syntheticWriteData"
 	case TxTypeSyntheticDepositTokens:
 		return "syntheticDepositTokens"
+	case TxTypeSyntheticAnchor:
+		return "syntheticAnchor"
 	case TxTypeSyntheticDepositCredits:
 		return "syntheticDepositCredits"
 	case TxTypeSyntheticBurnTokens:


### PR DESCRIPTION
At the beginning of block N+1, if block N made changes, the BVN builds a synthetic transaction containing various anchors and sends it to the DN.