### PR TITLE
Mirror BVN ADIs to DN

### DIFF
--- a/internal/accumulated/run.go
+++ b/internal/accumulated/run.go
@@ -205,6 +205,8 @@ func (d *Daemon) Start() error {
 		return fmt.Errorf("failed to start API: %v", err)
 	}
 
+	jrpc.EnableDebug(lclient)
+
 	// Run JSON-RPC server
 	d.api = &http.Server{Handler: jrpc.NewMux()}
 	l, secure, err := listenHttpUrl(d.Config.Accumulate.API.JSONListenAddress)

--- a/internal/api/v2/jrpc.go
+++ b/internal/api/v2/jrpc.go
@@ -155,6 +155,20 @@ func (m *JrpcMethods) logError(msg string, keyVals ...interface{}) {
 	}
 }
 
+func (m *JrpcMethods) EnableDebug(local ABCIQueryClient) {
+	q := &queryDirect{client: local}
+
+	m.methods["debug-query-direct"] = func(_ context.Context, params json.RawMessage) interface{} {
+		req := new(UrlQuery)
+		err := m.parse(params, req)
+		if err != nil {
+			return err
+		}
+
+		return jrpcFormatQuery(q.QueryUrl(req.Url))
+	}
+}
+
 func (m *JrpcMethods) NewMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/v1", m.v1.Handler())

--- a/internal/api/v2/types.yml
+++ b/internal/api/v2/types.yml
@@ -86,8 +86,6 @@ DirectoryQueryResult:
     type: uvarint
     keep-empty: true
 
-
-
 KeyPage:
   non-binary: true
   incomparable: true

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -17,6 +17,7 @@ func NewNodeExecutor(opts ExecutorOptions) (*Executor, error) {
 	case config.Directory:
 		return newExecutor(opts,
 			SyntheticAnchor{SubnetType: opts.SubnetType},
+			SyntheticMirror{},
 		)
 
 	case config.BlockValidator:
@@ -35,6 +36,7 @@ func NewNodeExecutor(opts ExecutorOptions) (*Executor, error) {
 			SyntheticDepositCredits{},
 			SyntheticSignTransactions{},
 			SyntheticAnchor{SubnetType: opts.SubnetType},
+			SyntheticMirror{},
 
 			// TODO Only for TestNet
 			AcmeFaucet{},

--- a/internal/chain/executor_query.go
+++ b/internal/chain/executor_query.go
@@ -63,13 +63,7 @@ func (m *Executor) queryByChainId(chainId []byte) (*query.ResponseByChainId, err
 }
 
 func (m *Executor) queryDirectoryByChainId(chainId []byte, start uint64, limit uint64) (*protocol.DirectoryQueryResult, error) {
-	b, err := m.DB.GetIndex(state.DirectoryIndex, chainId, "Metadata")
-	if err != nil {
-		return nil, err
-	}
-
-	md := new(protocol.DirectoryIndexMetadata)
-	err = md.UnmarshalBinary(b)
+	md, err := m.loadDirectoryMetadata(chainId)
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +80,10 @@ func (m *Executor) queryDirectoryByChainId(chainId []byte, start uint64, limit u
 	resp.Entries = make([]string, count)
 
 	for i := uint64(0); i < count; i++ {
-		b, err := m.DB.GetIndex(state.DirectoryIndex, chainId, start+i)
+		resp.Entries[i], err = m.loadDirectoryEntry(chainId, start+i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get entry %d", i)
 		}
-		resp.Entries[i] = string(b)
 	}
 	resp.Total = md.Count
 

--- a/internal/chain/executor_utils.go
+++ b/internal/chain/executor_utils.go
@@ -1,0 +1,70 @@
+package chain
+
+import (
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/internal/url"
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types/state"
+)
+
+func (m *Executor) loadDirectoryMetadata(chainId []byte) (*protocol.DirectoryIndexMetadata, error) {
+	b, err := m.DB.GetIndex(state.DirectoryIndex, chainId, "Metadata")
+	if err != nil {
+		return nil, err
+	}
+
+	md := new(protocol.DirectoryIndexMetadata)
+	err = md.UnmarshalBinary(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return md, nil
+}
+
+func (m *Executor) loadDirectoryEntry(chainId []byte, index uint64) (string, error) {
+	b, err := m.DB.GetIndex(state.DirectoryIndex, chainId, index)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (m *Executor) mirrorADIs(urls ...*url.URL) (*protocol.SyntheticMirror, error) {
+	mirror := new(protocol.SyntheticMirror)
+
+	for _, u := range urls {
+		chainId := u.ResourceChain()
+		obj, _, err := m.dbTx.LoadChain(chainId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load %q: %v", u, err)
+		}
+		mirror.Objects = append(mirror.Objects, obj)
+
+		md, err := m.loadDirectoryMetadata(chainId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load directory for %q: %v", u, err)
+		}
+
+		for i := uint64(0); i < md.Count; i++ {
+			s, err := m.loadDirectoryEntry(chainId, i)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load directory entry %d", i)
+			}
+
+			u, err := url.Parse(s)
+			if err != nil {
+				return nil, fmt.Errorf("invalid url %q: %v", s, err)
+			}
+
+			obj, _, err := m.dbTx.LoadChain(u.ResourceChain())
+			if err != nil {
+				return nil, fmt.Errorf("failed to load %q: %v", u, err)
+			}
+			mirror.Objects = append(mirror.Objects, obj)
+		}
+	}
+
+	return mirror, nil
+}

--- a/internal/chain/synthetic_mirror.go
+++ b/internal/chain/synthetic_mirror.go
@@ -1,0 +1,43 @@
+package chain
+
+import (
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/protocol"
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
+)
+
+type SyntheticMirror struct{}
+
+func (SyntheticMirror) Type() types.TxType { return types.TxTypeSyntheticMirror }
+
+func (SyntheticMirror) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(protocol.SyntheticMirror)
+	err := tx.As(body)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %v", err)
+	}
+
+	for _, obj := range body.Objects {
+		// TODO Check merkle tree
+
+		// Unmarshal the record
+		record, err := unmarshalRecord(obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal record: %v", err)
+		}
+
+		// Ensure the URL is valid
+		_, err = record.Header().ParseUrl()
+		if err != nil {
+			return fmt.Errorf("invalid chain URL: %v", record.Header().ChainUrl)
+		}
+
+		// TODO Save the merkle state somewhere?
+		fmt.Printf("Mirrored %q\n", record.Header().ChainUrl)
+		st.Update(record)
+	}
+
+	return nil
+}

--- a/internal/genesis/bootstrap.go
+++ b/internal/genesis/bootstrap.go
@@ -42,7 +42,7 @@ func Init(kvdb storage.KeyValueDB, opts InitOpts) ([]byte, error) {
 		return nil, err
 	}
 
-	return exec.Genesis(opts.GenesisTime, func(st *chain.StateManager) {
+	return exec.Genesis(opts.GenesisTime, func(st *chain.StateManager) error {
 		acme := new(protocol.TokenIssuer)
 		acme.Type = types.ChainTypeTokenIssuer
 		acme.ChainUrl = types.String(protocol.AcmeUrl().String())
@@ -88,5 +88,6 @@ func Init(kvdb storage.KeyValueDB, opts InitOpts) ([]byte, error) {
 		}
 
 		st.Update(adi, book, page)
+		return st.AddDirectoryEntry(uAdi, uBook, uPage)
 	})
 }

--- a/protocol/types.yml
+++ b/protocol/types.yml
@@ -354,3 +354,13 @@ SyntheticAnchor:
       type: chain
     - name: Chains
       type: chainSet
+
+SyntheticMirror:
+  kind: tx
+  fields:
+    - name: Objects
+      type: slice
+      slice:
+        type: state.Object
+        pointer: true
+        marshal-as: reference

--- a/types/state/anchor_chain.go
+++ b/types/state/anchor_chain.go
@@ -24,6 +24,28 @@ func (ac *AnchorChainManager) Record() (*Anchor, error) {
 	return record, err
 }
 
+// AddSystemTxns appends the given transaction IDs to the anchor head, without
+// updating the chain.
+func (ac *AnchorChainManager) AddSystemTxns(txids ...[32]byte) error {
+	if len(txids) == 0 {
+		return nil
+	}
+
+	head, err := ac.Record()
+	if err != nil {
+		return err
+	}
+
+	// We're only updating the head record, we are not adding anything to the chain
+	head.SystemTxns = append(head.SystemTxns, txids...)
+	err = ac.Chain.UpdateAs(head)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (ac *AnchorChainManager) Update(index int64, timestamp time.Time, chains [][32]byte) error {
 	// Sort the chain IDs
 	sort.Slice(chains, func(i, j int) bool {

--- a/types/state/types.yml
+++ b/types/state/types.yml
@@ -26,7 +26,7 @@ Anchor:
       type: chain
     - name: Synthetic
       type: chain
-    - name: AnchorTxns
+    - name: SystemTxns
       type: chainSet
 
 SyntheticSignature:

--- a/types/state/types_gen.go
+++ b/types/state/types_gen.go
@@ -20,7 +20,7 @@ type Anchor struct {
 	Chains      [][32]byte `json:"chains,omitempty" form:"chains" query:"chains" validate:"required"`
 	ChainAnchor [32]byte   `json:"chainAnchor,omitempty" form:"chainAnchor" query:"chainAnchor" validate:"required"`
 	Synthetic   [32]byte   `json:"synthetic,omitempty" form:"synthetic" query:"synthetic" validate:"required"`
-	AnchorTxns  [][32]byte `json:"anchorTxns,omitempty" form:"anchorTxns" query:"anchorTxns" validate:"required"`
+	SystemTxns  [][32]byte `json:"systemTxns,omitempty" form:"systemTxns" query:"systemTxns" validate:"required"`
 }
 
 type Object struct {
@@ -91,12 +91,12 @@ func (v *Anchor) Equal(u *Anchor) bool {
 		return false
 	}
 
-	if !(len(v.AnchorTxns) == len(u.AnchorTxns)) {
+	if !(len(v.SystemTxns) == len(u.SystemTxns)) {
 		return false
 	}
 
-	for i := range v.AnchorTxns {
-		if v.AnchorTxns[i] != u.AnchorTxns[i] {
+	for i := range v.SystemTxns {
+		if v.SystemTxns[i] != u.SystemTxns[i] {
 			return false
 		}
 	}
@@ -200,7 +200,7 @@ func (v *Anchor) BinarySize() int {
 
 	n += encoding.ChainBinarySize(&v.Synthetic)
 
-	n += encoding.ChainSetBinarySize(v.AnchorTxns)
+	n += encoding.ChainSetBinarySize(v.SystemTxns)
 
 	return n
 }
@@ -283,7 +283,7 @@ func (v *Anchor) MarshalBinary() ([]byte, error) {
 
 	buffer.Write(encoding.ChainMarshalBinary(&v.Synthetic))
 
-	buffer.Write(encoding.ChainSetMarshalBinary(v.AnchorTxns))
+	buffer.Write(encoding.ChainSetMarshalBinary(v.SystemTxns))
 
 	return buffer.Bytes(), nil
 }
@@ -402,11 +402,11 @@ func (v *Anchor) UnmarshalBinary(data []byte) error {
 	data = data[encoding.ChainBinarySize(&v.Synthetic):]
 
 	if x, err := encoding.ChainSetUnmarshalBinary(data); err != nil {
-		return fmt.Errorf("error decoding AnchorTxns: %w", err)
+		return fmt.Errorf("error decoding SystemTxns: %w", err)
 	} else {
-		v.AnchorTxns = x
+		v.SystemTxns = x
 	}
-	data = data[encoding.ChainSetBinarySize(v.AnchorTxns):]
+	data = data[encoding.ChainSetBinarySize(v.SystemTxns):]
 
 	return nil
 }
@@ -539,7 +539,7 @@ func (v *Anchor) MarshalJSON() ([]byte, error) {
 		Chains      []string  `json:"chains,omitempty"`
 		ChainAnchor string    `json:"chainAnchor,omitempty"`
 		Synthetic   string    `json:"synthetic,omitempty"`
-		AnchorTxns  []string  `json:"anchorTxns,omitempty"`
+		SystemTxns  []string  `json:"systemTxns,omitempty"`
 	}{}
 	u.ChainHeader = v.ChainHeader
 	u.Index = v.Index
@@ -548,7 +548,7 @@ func (v *Anchor) MarshalJSON() ([]byte, error) {
 	u.Chains = encoding.ChainSetToJSON(v.Chains)
 	u.ChainAnchor = encoding.ChainToJSON(v.ChainAnchor)
 	u.Synthetic = encoding.ChainToJSON(v.Synthetic)
-	u.AnchorTxns = encoding.ChainSetToJSON(v.AnchorTxns)
+	u.SystemTxns = encoding.ChainSetToJSON(v.SystemTxns)
 	return json.Marshal(&u)
 }
 
@@ -590,7 +590,7 @@ func (v *Anchor) UnmarshalJSON(data []byte) error {
 		Chains      []string  `json:"chains,omitempty"`
 		ChainAnchor string    `json:"chainAnchor,omitempty"`
 		Synthetic   string    `json:"synthetic,omitempty"`
-		AnchorTxns  []string  `json:"anchorTxns,omitempty"`
+		SystemTxns  []string  `json:"systemTxns,omitempty"`
 	}{}
 	u.ChainHeader = v.ChainHeader
 	u.Index = v.Index
@@ -599,7 +599,7 @@ func (v *Anchor) UnmarshalJSON(data []byte) error {
 	u.Chains = encoding.ChainSetToJSON(v.Chains)
 	u.ChainAnchor = encoding.ChainToJSON(v.ChainAnchor)
 	u.Synthetic = encoding.ChainToJSON(v.Synthetic)
-	u.AnchorTxns = encoding.ChainSetToJSON(v.AnchorTxns)
+	u.SystemTxns = encoding.ChainSetToJSON(v.SystemTxns)
 	if err := json.Unmarshal(data, &u); err != nil {
 		return err
 	}
@@ -626,10 +626,10 @@ func (v *Anchor) UnmarshalJSON(data []byte) error {
 	} else {
 		v.Synthetic = x
 	}
-	if x, err := encoding.ChainSetFromJSON(u.AnchorTxns); err != nil {
-		return fmt.Errorf("error decoding AnchorTxns: %w", err)
+	if x, err := encoding.ChainSetFromJSON(u.SystemTxns); err != nil {
+		return fmt.Errorf("error decoding SystemTxns: %w", err)
 	} else {
-		v.AnchorTxns = x
+		v.SystemTxns = x
 	}
 	return nil
 }

--- a/types/transaction_types.go
+++ b/types/transaction_types.go
@@ -111,9 +111,12 @@ const (
 	// TxTypeSyntheticGenesis initializes system chains.
 	TxTypeSyntheticGenesis TransactionType = 0x37
 
+	// TxTypeSyntheticMirror mirrors records from one network to another.
+	TxTypeSyntheticMirror TransactionType = 0x38
+
 	// TxTypeSegWitDataEntry is a surrogate transaction segregated witness for
 	// a WriteData transaction
-	TxTypeSegWitDataEntry TransactionType = 0x38
+	TxTypeSegWitDataEntry TransactionType = 0x39
 )
 
 // IsSynthetic returns true if the transaction type is synthetic.
@@ -171,6 +174,8 @@ func (t TransactionType) String() string {
 		return "syntheticBurnTokens"
 	case TxTypeSyntheticGenesis:
 		return "syntheticGenesis"
+	case TxTypeSyntheticMirror:
+		return "syntheticMirror"
 	case TxTypeSegWitDataEntry:
 		return "segWitDataEntry"
 	default:


### PR DESCRIPTION
Mirrors the BVN ADIs to the DN.

To verify, start a local devnet, wait for it to settle, then run `curl -s -X POST --data '{ "jsonrpc": "2.0", "id": 0, "method": "debug-query-direct", "params": { "url": "bvn-DevNet.BVN0/validators0" } }' -H 'content-type:application/json;' ${SERVER}` against the DN to verify that the DN has the BVN's keys.