### PR TITLE
Consolidate chain unmarshalling

### DIFF
--- a/internal/api/v2/query_direct.go
+++ b/internal/api/v2/query_direct.go
@@ -137,7 +137,7 @@ func responseDirFromProto(protoDir *protocol.DirectoryQueryResult, pagination *Q
 	respDir.Total = protoDir.Total
 	respDir.ExpandedEntries = make([]*QueryResponse, len(protoDir.ExpandedEntries))
 	for i, entry := range protoDir.ExpandedEntries {
-		chain, err := chainFromStateObj(entry)
+		chain, err := protocol.UnmarshalChain(entry.Entry)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/api/v2/unmarshal.go
+++ b/internal/api/v2/unmarshal.go
@@ -18,51 +18,12 @@ func unmarshalState(b []byte) (*state.Object, state.Chain, error) {
 		return nil, nil, fmt.Errorf("invalid state response: %v", err)
 	}
 
-	chain, err := chainFromStateObj(&obj)
+	chain, err := protocol.UnmarshalChain(obj.Entry)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return &obj, chain, nil
-}
-
-func chainFromStateObj(obj *state.Object) (state.Chain, error) {
-
-	var header state.ChainHeader
-	var chain state.Chain
-	err := obj.As(&header)
-	if err != nil {
-		return nil, fmt.Errorf("invalid state response: %v", err)
-	}
-
-	switch header.Type {
-	case types.ChainTypeIdentity:
-		chain = new(state.AdiState)
-	case types.ChainTypeTokenIssuer:
-		chain = new(protocol.TokenIssuer)
-	case types.ChainTypeTokenAccount:
-		chain = new(state.TokenAccount)
-	case types.ChainTypeLiteTokenAccount:
-		chain = new(protocol.LiteTokenAccount)
-	case types.ChainTypeKeyPage:
-		chain = new(protocol.KeyPage)
-	case types.ChainTypeKeyBook:
-		chain = new(protocol.KeyBook)
-	case types.ChainTypeTransaction:
-		chain = new(state.Transaction)
-	case types.ChainTypeDataAccount:
-		chain = new(protocol.DataAccount)
-	case types.ChainTypeLiteDataAccount:
-		chain = new(protocol.LiteDataAccount)
-	default:
-		return nil, fmt.Errorf("unknown chain type %v", header.Type)
-	}
-
-	err = obj.As(chain)
-	if err != nil {
-		return nil, fmt.Errorf("invalid state response: %v", err)
-	}
-	return chain, nil
 }
 
 func unmarshalTxType(b []byte) types.TxType {

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -375,46 +375,7 @@ func (m *StateManager) Commit() error {
 }
 
 func unmarshalRecord(obj *state.Object) (state.Chain, error) {
-	header := new(state.ChainHeader)
-	err := obj.As(header)
-	if err != nil {
-		return nil, err
-	}
-
-	var record state.Chain
-	switch header.Type {
-	case types.ChainTypeTokenIssuer:
-		record = new(protocol.TokenIssuer)
-	case types.ChainTypeIdentity:
-		record = new(state.AdiState)
-	case types.ChainTypeTokenAccount:
-		record = new(state.TokenAccount)
-	case types.ChainTypeLiteTokenAccount:
-		record = new(protocol.LiteTokenAccount)
-	case types.ChainTypeTransactionReference:
-		record = new(state.TxReference)
-	case types.ChainTypeTransaction:
-		record = new(state.Transaction)
-	case types.ChainTypePendingTransaction:
-		record = new(state.PendingTransaction)
-	case types.ChainTypeKeyPage:
-		record = new(protocol.KeyPage)
-	case types.ChainTypeKeyBook:
-		record = new(protocol.KeyBook)
-	case types.ChainTypeDataAccount:
-		record = new(protocol.DataAccount)
-	case types.ChainTypeLiteDataAccount:
-		record = new(protocol.LiteDataAccount)
-	default:
-		return nil, fmt.Errorf("unrecognized chain type %v", header.Type)
-	}
-
-	err = obj.As(record)
-	if err != nil {
-		return nil, err
-	}
-
-	return record, nil
+	return protocol.UnmarshalChain(obj.Entry)
 }
 
 func (s *StateManager) WriteIndex(index state.Index, chain []byte, key interface{}, value []byte) {

--- a/protocol/chain.go
+++ b/protocol/chain.go
@@ -1,0 +1,59 @@
+package protocol
+
+import (
+	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/types"
+	"github.com/AccumulateNetwork/accumulate/types/state"
+)
+
+func NewChain(typ types.ChainType) (state.Chain, error) {
+	switch typ {
+	case types.ChainTypeIdentity:
+		return new(state.AdiState), nil
+	case types.ChainTypeTokenIssuer:
+		return new(TokenIssuer), nil
+	case types.ChainTypeTokenAccount:
+		return new(state.TokenAccount), nil
+	case types.ChainTypeLiteTokenAccount:
+		return new(LiteTokenAccount), nil
+	case types.ChainTypeTransactionReference:
+		return new(state.TxReference), nil
+	case types.ChainTypeTransaction:
+		return new(state.Transaction), nil
+	case types.ChainTypePendingTransaction:
+		return new(state.PendingTransaction), nil
+	case types.ChainTypeKeyPage:
+		return new(KeyPage), nil
+	case types.ChainTypeKeyBook:
+		return new(KeyBook), nil
+	case types.ChainTypeDataAccount:
+		return new(DataAccount), nil
+	case types.ChainTypeLiteDataAccount:
+		return new(LiteDataAccount), nil
+	case types.ChainTypeSyntheticTransactions:
+		return new(state.SyntheticTransactionChain), nil
+	default:
+		return nil, fmt.Errorf("unknown chain type %v", typ)
+	}
+}
+
+func UnmarshalChain(data []byte) (state.Chain, error) {
+	header := new(state.ChainHeader)
+	err := header.UnmarshalBinary(data)
+	if err != nil {
+		return nil, err
+	}
+
+	chain, err := NewChain(header.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	err = chain.UnmarshalBinary(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return chain, nil
+}


### PR DESCRIPTION
Consolidates unmarshalling of chains, so that there's only one switch-on-chain-type instead of three.

No functional changes. To verify, run a devnet and test it.