### PR TITLE
fix: API v1 token-tx

### DIFF
--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -532,10 +532,6 @@ func (api *API) getTokenTx(_ context.Context, params json.RawMessage) interface{
 		return transactionError(err)
 	}
 
-	if resp.Type != "tokenTx" && resp.Type != "syntheticTokenDeposit" {
-		return invalidTxnTypeError(fmt.Errorf("transaction type is %s and not a token transaction", resp.Type))
-	}
-
 	return resp
 }
 


### PR DESCRIPTION
The transaction type check is using out of date transaction type names. API v1 is deprecated, so I just removed the check.