### PR TITLE
Refactor DB keys

### DIFF
--- a/internal/chain/executor.go
+++ b/internal/chain/executor.go
@@ -185,7 +185,7 @@ func (m *Executor) InitChain(data []byte) error {
 
 	// Load the BPT root hash so we can verify the system state
 	var hash [32]byte
-	data, err = src.Get(storage.ComputeKey("BPT", "Root"))
+	data, err = src.Get(storage.MakeKey("BPT", "Root"))
 	switch {
 	case err == nil:
 		bpt := new(pmt.BPT)

--- a/internal/chain/executor_synthetic.go
+++ b/internal/chain/executor_synthetic.go
@@ -20,7 +20,7 @@ import (
 
 // synthCount returns the number of synthetic transactions sent by this subnet.
 func (m *Executor) synthCount() (uint64, error) {
-	k := storage.ComputeKey("SyntheticTransactionCount")
+	k := storage.MakeKey("SyntheticTransactionCount")
 	b, err := m.dbTx.Read(k)
 	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return 0, err

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -407,12 +407,12 @@ func unmarshalRecord(obj *state.Object) (state.Chain, error) {
 }
 
 func (s *StateManager) WriteIndex(index state.Index, chain []byte, key interface{}, value []byte) {
-	k := storage.ComputeKey(string(index), chain, key)
+	k := storage.MakeKey(string(index), chain, key)
 	s.writes[k] = value
 }
 
 func (s *StateManager) GetIndex(index state.Index, chain []byte, key interface{}) ([]byte, error) {
-	k := storage.ComputeKey(string(index), chain, key)
+	k := storage.MakeKey(string(index), chain, key)
 	w, ok := s.writes[k]
 	if ok {
 		return w, nil

--- a/internal/genesis/bootstrap.go
+++ b/internal/genesis/bootstrap.go
@@ -35,7 +35,7 @@ func Init(kvdb storage.KeyValueDB, opts InitOpts) ([]byte, error) {
 		return nil, err
 	}
 
-	_ = kvdb.Put(storage.ComputeKey("SubnetID"), []byte(opts.SubnetID))
+	_ = kvdb.Put(storage.MakeKey("SubnetID"), []byte(opts.SubnetID))
 
 	exec, err := chain.NewGenesisExecutor(db, opts.NetworkType)
 	if err != nil {

--- a/smt/managed/blockIndex.go
+++ b/smt/managed/blockIndex.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/AccumulateNetwork/accumulate/smt/common"
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
 )
 
 // BlockIndex
@@ -59,19 +60,19 @@ func EndBlock(manager *MerkleManager, cID []byte, blockIndex uint64) error {
 	bIdx[31] += 2        //
 	b := new(BlockIndex) // allocate a block index
 
-	err := manager.SetKey(cID[:])
+	err := manager.SetKey(storage.MakeKey(cID[:]))
 	if err != nil {
 		return err
 	}
 	b.MainIndex = uint64(manager.MS.Count)
 
-	err = manager.SetKey(pID[:])
+	err = manager.SetKey(storage.MakeKey(pID[:]))
 	if err != nil {
 		return err
 	}
 	b.PendingIndex = uint64(manager.MS.Count)
 
-	err = manager.SetKey(bIdx[:])
+	err = manager.SetKey(storage.MakeKey(bIdx[:]))
 	if err != nil {
 		return err
 	}
@@ -80,7 +81,7 @@ func EndBlock(manager *MerkleManager, cID []byte, blockIndex uint64) error {
 	data := b.Marshal()
 	blkIdxHash := manager.MS.HashFunction(data)
 	manager.AddHash(blkIdxHash)
-	manager.Manager.Key(blkIdxHash).PutBatch(data)
+	manager.Manager.PutBatch(storage.MakeKey(blkIdxHash), data)
 
 	return nil
 }

--- a/smt/managed/merklemanagerrange.go
+++ b/smt/managed/merklemanagerrange.go
@@ -3,6 +3,8 @@ package managed
 import (
 	"errors"
 	"fmt"
+
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
 )
 
 // GetRange
@@ -10,9 +12,9 @@ import (
 // begin must be before or equal to end.  The hash with index begin upto
 // but not including end are the hashes returned.  Indexes are zero based, so the
 // first hash in the MerkleState is at 0
-func (m *MerkleManager) GetRange(key []interface{}, begin, end int64) (hashes []Hash, err error) {
+func (m *MerkleManager) GetRange(key storage.Key, begin, end int64) (hashes []Hash, err error) {
 	// We return nothing for ranges that are out of range.
-	if err := m.SetKey(key...); err != nil {
+	if err := m.SetKey(key); err != nil {
 		return nil, err
 	}
 
@@ -41,7 +43,7 @@ func (m *MerkleManager) GetRange(key []interface{}, begin, end int64) (hashes []
 		if s = m.GetState(markPoint - 1); s != nil {
 			hl = append(hl, s.HashList...)
 		} else {
-			s, err = m.GetChainState(m.key...)
+			s, err = m.GetChainState(m.key)
 			if err != nil {
 				return nil, errors.New("a chain should always have a chain state")
 			}

--- a/smt/managed/merklemanagerrange_test.go
+++ b/smt/managed/merklemanagerrange_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/AccumulateNetwork/accumulate/smt/storage"
 	"github.com/AccumulateNetwork/accumulate/smt/storage/database"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func TestMerkleManager_GetRange(t *testing.T) {
 		require.NoError(t, err, "should create db")
 		mm, err := NewMerkleManager(db, 2)
 		require.NoError(t, err, "should create MerkleManager")
-		err = mm.SetKey("try")
+		err = mm.SetKey(storage.MakeKey("try"))
 		require.NoError(t, err, "should be able to set a key")
 		for i := int64(0); i < NumTests; i++ {
 			mm.AddHash(rh.NextList())
@@ -43,7 +44,7 @@ func TestMerkleManager_GetRange(t *testing.T) {
 		for begin := int64(-1); begin < NumTests+1; begin++ {
 			for end := begin - 1; end < NumTests+2; end++ {
 
-				hashes, err := mm.GetRange([]interface{}{"try"}, begin, end)
+				hashes, err := mm.GetRange(mm.key, begin, end)
 
 				if begin < 0 || begin > end || begin >= NumTests {
 					require.Errorf(t, err, "should not allow range [%d,%d]", begin, end)

--- a/types/state/StateDB.go
+++ b/types/state/StateDB.go
@@ -198,7 +198,7 @@ func (s *StateDB) GetDataChainRange(chainId []byte, start int64, end int64) ([]t
 
 //GetTx get the transaction by transaction ID
 func (s *StateDB) GetTx(txId []byte) (tx []byte, err error) {
-	tx, err = s.dbMgr.Key(bucketTx, txId).Get()
+	tx, err = s.dbMgr.Get(storage.MakeKey(bucketTx, txId))
 	if err != nil {
 		return nil, err
 	}
@@ -209,11 +209,11 @@ func (s *StateDB) GetTx(txId []byte) (tx []byte, err error) {
 //GetPendingTx get the pending transactions by primary transaction ID
 func (s *StateDB) GetPendingTx(txId []byte) (pendingTx []byte, err error) {
 
-	pendingTxId, err := s.dbMgr.Key(bucketMainToPending, txId).Get()
+	pendingTxId, err := s.dbMgr.Get(storage.MakeKey(bucketMainToPending, txId))
 	if err != nil {
 		return nil, err
 	}
-	pendingTx, err = s.dbMgr.Key(bucketPendingTx, pendingTxId).Get()
+	pendingTx, err = s.dbMgr.Get(storage.MakeKey(bucketPendingTx, pendingTxId))
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (s *StateDB) GetPendingTx(txId []byte) (pendingTx []byte, err error) {
 // GetSyntheticTxIds get the transaction id list by the transaction ID that spawned the synthetic transactions
 func (s *StateDB) GetSyntheticTxIds(txId []byte) (syntheticTxIds []byte, err error) {
 
-	syntheticTxIds, err = s.dbMgr.Key(bucketTxToSynthTx, txId).Get()
+	syntheticTxIds, err = s.dbMgr.Get(storage.MakeKey(bucketTxToSynthTx, txId))
 	if err != nil {
 		//this is not a significant error. Synthetic transactions don't usually have other synth tx's.
 		//TODO: Fixme, this isn't an error
@@ -309,7 +309,7 @@ func (s *StateDB) GetPersistentEntry(chainId []byte, verify bool) (*Object, erro
 		return nil, fmt.Errorf("database has not been initialized")
 	}
 
-	data, err := s.dbMgr.Key("StateEntries", chainId).Get()
+	data, err := s.dbMgr.Get(storage.MakeKey("StateEntries", chainId))
 	if errors.Is(err, storage.ErrNotFound) {
 		return nil, fmt.Errorf("%w: no state defined for %X", storage.ErrNotFound, chainId)
 	}
@@ -335,7 +335,7 @@ func (s *StateDB) getObject(keys ...interface{}) (*Object, error) {
 		return nil, fmt.Errorf("database has not been initialized")
 	}
 
-	data, err := s.dbMgr.Key(keys...).Get()
+	data, err := s.dbMgr.Get(storage.MakeKey(keys...))
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +480,7 @@ func (tx *DBTransaction) WriteSynthTxn(txid []byte, obj *Object) error {
 
 	tx.state.logInfo("Write synth txn", "txid", logging.AsHex(txid))
 
-	tx.state.dbMgr.Key(bucketStagedSynthTx, "", txid).PutBatch(data)
+	tx.state.dbMgr.PutBatch(storage.MakeKey(bucketStagedSynthTx, "", txid), data)
 	tx.state.bptMgr.Bpt.Insert(txid32, sha256.Sum256(data))
 	return nil
 }
@@ -503,12 +503,12 @@ func (tx *DBTransaction) writeTxs(mutex *sync.Mutex, group *sync.WaitGroup) erro
 				}
 			}
 			//store a list of txid to list of synth txid's
-			tx.state.dbMgr.Key(bucketTxToSynthTx, txn.TxId).PutBatch(synthData)
+			tx.state.dbMgr.PutBatch(storage.MakeKey(bucketTxToSynthTx, txn.TxId), synthData)
 		}
 
 		mutex.Lock()
 		//store the transaction in the transaction bucket by txid
-		tx.state.dbMgr.Key(bucketTx, txn.TxId).PutBatch(data)
+		tx.state.dbMgr.PutBatch(storage.MakeKey(bucketTx, txn.TxId), data)
 		//insert the hash of the tx object in the BPT
 		tx.state.bptMgr.Bpt.Insert(txHash, sha256.Sum256(data))
 		mutex.Unlock()
@@ -524,10 +524,10 @@ func (tx *DBTransaction) writeTxs(mutex *sync.Mutex, group *sync.WaitGroup) erro
 		mutex.Lock()
 		//Store the mapping of the Transaction hash to the pending transaction hash which can be used for
 		// validation so we can find the pending transaction
-		tx.state.dbMgr.Key("MainToPending", txn.TxId).PutBatch(pendingHash[:])
+		tx.state.dbMgr.PutBatch(storage.MakeKey("MainToPending", txn.TxId), pendingHash[:])
 
 		//store the pending transaction by the pending tx hash
-		tx.state.dbMgr.Key(bucketPendingTx, pendingHash[:]).PutBatch(data)
+		tx.state.dbMgr.PutBatch(storage.MakeKey(bucketPendingTx, pendingHash[:]), data)
 		mutex.Unlock()
 	}
 
@@ -537,7 +537,7 @@ func (tx *DBTransaction) writeTxs(mutex *sync.Mutex, group *sync.WaitGroup) erro
 func (tx *DBTransaction) writeChainState(group *sync.WaitGroup, mutex *sync.Mutex, mm *managed.MerkleManager, chainId types.Bytes32) error {
 	defer group.Done()
 
-	err := tx.state.merkleMgr.SetKey(chainId[:])
+	err := tx.state.merkleMgr.SetKey(storage.MakeKey(chainId[:]))
 	if err != nil {
 		return err
 	}
@@ -579,7 +579,7 @@ func (tx *DBTransaction) writeChainState(group *sync.WaitGroup, mutex *sync.Mute
 		}
 
 		mutex.Lock()
-		tx.GetDB().Key(bucketEntry, chainId.Bytes()).PutBatch(chainStateObject)
+		tx.GetDB().PutBatch(storage.MakeKey(bucketEntry, chainId.Bytes()), chainStateObject)
 		// The bpt stores the hash of the ChainState object hash.
 		tx.state.bptMgr.Bpt.Insert(chainId, sha256.Sum256(chainStateObject))
 		mutex.Unlock()
@@ -615,13 +615,13 @@ func (tx *DBTransaction) writeDataState(chainId *types.Bytes32) error {
 		//store the entry hash for the data
 		tx.state.logDebug("AddHash", "hash", logging.AsHex(entry.EntryHash))
 		mgr.AddEntry(entry.EntryHash)
-		tx.GetDB().Key(bucketEntry, chainId.Bytes(), entry.EntryHash).PutBatch(entry.Data)
+		tx.GetDB().PutBatch(storage.MakeKey(bucketEntry, chainId.Bytes(), entry.EntryHash), entry.Data)
 	}
 
 	// The bpt stores the root of the data merkle state
 	anchor := types.Bytes32{}
 	anchor.FromBytes(mgr.Anchor())
-	tx.state.bptMgr.Bpt.Insert(storage.ComputeKey(bucketDataEntry, chainId), anchor)
+	tx.state.bptMgr.Bpt.Insert(storage.MakeKey(bucketDataEntry, chainId), anchor)
 	return nil
 }
 
@@ -727,7 +727,7 @@ func (tx *DBTransaction) writeBatches() {
 }
 
 func (s *StateDB) SubnetID() (string, error) {
-	b, err := s.GetDB().Key("SubnetID").Get()
+	b, err := s.GetDB().Get(storage.MakeKey("SubnetID"))
 	if err != nil {
 		return "", err
 	}
@@ -880,7 +880,7 @@ func (tx *DBTransaction) commitTxWrites() {
 		return bytes.Compare(writeOrder[i][:], writeOrder[j][:]) < 0
 	})
 	for _, k := range writeOrder {
-		tx.state.GetDB().Key(k).PutBatch(tx.writes[k])
+		tx.state.GetDB().PutBatch(storage.MakeKey(k), tx.writes[k])
 	}
 }
 

--- a/types/state/StateDB_test.go
+++ b/types/state/StateDB_test.go
@@ -19,7 +19,7 @@ func TestStateDB_GetChainRange(t *testing.T) {
 	s.merkleMgr.MarkMask = s.merkleMgr.MarkFreq - 1
 
 	id := []byte(t.Name())
-	require.NoError(t, s.merkleMgr.SetKey(id))
+	require.NoError(t, s.merkleMgr.SetKey(storage.MakeKey(id)))
 
 	const N = 10
 	for i := byte(0); i < N; i++ {

--- a/types/state/index.go
+++ b/types/state/index.go
@@ -29,23 +29,23 @@ func (tx *DBTransaction) Read(key storage.Key) ([]byte, error) {
 }
 
 func (db *StateDB) Read(key storage.Key) ([]byte, error) {
-	return db.GetDB().Key(key).Get()
+	return db.GetDB().Get(key)
 }
 
 func (tx *DBTransaction) WriteIndex(index Index, chain []byte, key interface{}, value []byte) {
-	k := storage.ComputeKey(string(index), chain, key)
+	k := storage.MakeKey(string(index), chain, key)
 	tx.state.logDebug("WriteIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "value", hex.EncodeToString(value), "computed", hex.EncodeToString(k[:]))
 	tx.Write(k, value)
 }
 
 func (tx *DBTransaction) GetIndex(index Index, chain []byte, key interface{}) ([]byte, error) {
-	k := storage.ComputeKey(string(index), chain, key)
+	k := storage.MakeKey(string(index), chain, key)
 	tx.state.logDebug("GetIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "computed", hex.EncodeToString(k[:]))
 	return tx.Read(k)
 }
 
 func (db *StateDB) GetIndex(index Index, chain []byte, key interface{}) ([]byte, error) {
-	k := storage.ComputeKey(string(index), chain, key)
+	k := storage.MakeKey(string(index), chain, key)
 	db.logDebug("GetIndex", "index", string(index), "chain", hex.EncodeToString(chain), "key", key, "computed", hex.EncodeToString(k[:]))
 	return db.Read(k)
 }


### PR DESCRIPTION
Stop using `key ...interface{}` and `key []interface{}` and instead pass around `key storage.Key`. Adds `func (Key) Append(...interface{}) Key` for convenience. Also, keys are calculated with H(H(H(v1)+v2)+v3) instead of H(v1 + v2 + v3).