### PR TITLE
Rename withdraw tokens txn to send tokens

### DIFF
--- a/cmd/cli/cmd/tx.go
+++ b/cmd/cli/cmd/tx.go
@@ -254,11 +254,11 @@ func CreateTX(sender string, args []string) (string, error) {
 	amount := args[1]
 
 	//fmt.Println(hex.EncodeToString(pk))
-	tokentx := new(acmeapi.TokenTx)
+	tokentx := new(acmeapi.SendTokens)
 	tokentx.From = types.UrlChain{String: types.String(u.String())}
 
-	to := []*acmeapi.TokenTxOutput{}
-	r := &acmeapi.TokenTxOutput{}
+	to := []*acmeapi.TokenRecipient{}
+	r := &acmeapi.TokenRecipient{}
 
 	amt, err := strconv.ParseFloat(amount, 64)
 	r.Amount = uint64(amt * 1e8)

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -698,7 +698,7 @@ func PrintQueryResponse(res *acmeapi.APIDataResponse) (string, error) {
 				out += fmt.Sprintf("\t%d\t%d\t%x\t%s", i, k.Nonce, k.PublicKey, keyName)
 			}
 			return out, nil
-		case types.TxTypeWithdrawTokens.String():
+		case types.TxTypeSendTokens.String():
 			tx := response.TokenTx{}
 			err := json.Unmarshal(*res.Data, &tx)
 			if err != nil {

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -538,7 +538,7 @@ func (api *API) getTokenTx(_ context.Context, params json.RawMessage) interface{
 
 // createTokenTx creates Token Tx
 func (api *API) createTokenTx(_ context.Context, params json.RawMessage) interface{} {
-	data := &acmeapi.TokenTx{}
+	data := &acmeapi.SendTokens{}
 	req, payload, err := api.prepareCreate(params, data, "From", "To")
 	if err != nil {
 		return validatorError(err)
@@ -583,7 +583,7 @@ func (api *API) Faucet(_ context.Context, params json.RawMessage) interface{} {
 		return jsonrpc2.NewError(ErrCodeNotAcmeAccount, "Invalid token account", fmt.Errorf("%q is not an ACME account", u))
 	}
 
-	tx := acmeapi.TokenTx{}
+	tx := acmeapi.SendTokens{}
 	tx.From.String = types.String(protocol.FaucetWallet.Addr)
 	tx.AddToAccount(destAccount, 1000000000)
 

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -434,7 +434,7 @@ func TestFaucetTransactionHistory(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Data, 2)
 	require.Equal(t, types.String(types.TxTypeSyntheticGenesis.Name()), resp.Data[0].Type)
-	require.Equal(t, types.String(types.TxTypeWithdrawTokens.Name()), resp.Data[1].Type)
+	require.Equal(t, types.String(types.TxTypeSendTokens.Name()), resp.Data[1].Type)
 }
 
 func TestMetrics(t *testing.T) {
@@ -601,7 +601,7 @@ func TestFaucetReplay(t *testing.T) {
 
 	_, kpSponsor, _ := ed25519.GenerateKey(nil)
 	destAccount := lite.GenerateAcmeAddress(kpSponsor.Public().(ed25519.PublicKey))
-	tx := acmeapi.TokenTx{}
+	tx := acmeapi.SendTokens{}
 	tx.From.String = types.String(protocol.FaucetWallet.Addr)
 	tx.AddToAccount(types.String(destAccount), 1000000000)
 

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -101,7 +101,7 @@ func unmarshalTxReference(rQuery tm.ResponseQuery) (*api.APIDataResponse, error)
 }
 
 func unmarshalTokenTx(txPayload []byte, txId types.Bytes, txSynthTxIds types.Bytes) (*api.APIDataResponse, error) {
-	tx := api.TokenTx{}
+	tx := api.SendTokens{}
 	err := tx.UnmarshalBinary(txPayload)
 	if err != nil {
 		return nil, accumulateError(err)
@@ -119,8 +119,8 @@ func unmarshalTokenTx(txPayload []byte, txId types.Bytes, txSynthTxIds types.Byt
 		j := i * 32
 		synthTxId := txSynthTxIds[j : j+32]
 		txStatus := response.TokenTxOutputStatus{}
-		txStatus.TokenTxOutput.URL = v.URL
-		txStatus.TokenTxOutput.Amount = v.Amount
+		txStatus.TokenRecipient.URL = v.URL
+		txStatus.TokenRecipient.Amount = v.Amount
 		txStatus.SyntheticTxId = synthTxId
 
 		txResp.ToAccount = append(txResp.ToAccount, txStatus)
@@ -131,7 +131,7 @@ func unmarshalTokenTx(txPayload []byte, txId types.Bytes, txSynthTxIds types.Byt
 		return nil, err
 	}
 	resp := api.APIDataResponse{}
-	resp.Type = types.String(types.TxTypeWithdrawTokens.Name())
+	resp.Type = types.String(types.TxTypeSendTokens.Name())
 	resp.Data = new(json.RawMessage)
 	*resp.Data = data
 	resp.Sponsor = tx.From.String
@@ -176,7 +176,7 @@ func unmarshalTransaction(sigInfo *transactions.SignatureInfo, txPayload []byte,
 
 	txType, _ := common.BytesUint64(txPayload)
 	switch types.TxType(txType) {
-	case types.TxTypeWithdrawTokens:
+	case types.TxTypeSendTokens:
 		resp, err = unmarshalTokenTx(txPayload, txId, txSynthTxIds)
 	case types.TxTypeSyntheticDepositTokens:
 		resp, err = unmarshalSynthTokenDeposit(txPayload, txId, txSynthTxIds)

--- a/internal/api/v2/jrpc.go
+++ b/internal/api/v2/jrpc.go
@@ -115,7 +115,7 @@ func NewJrpc(opts JrpcOptions) (*JrpcMethods, error) {
 		"create-key-page":      m.ExecuteWith(func() PL { return new(protocol.CreateKeyPage) }),
 		"create-token":         m.ExecuteWith(func() PL { return new(protocol.CreateToken) }),
 		"create-token-account": m.ExecuteWith(func() PL { return new(protocol.TokenAccountCreate) }),
-		"send-tokens":          m.ExecuteWith(func() PL { return new(api.TokenTx) }, "From", "To"),
+		"send-tokens":          m.ExecuteWith(func() PL { return new(api.SendTokens) }, "From", "To"),
 		"add-credits":          m.ExecuteWith(func() PL { return new(protocol.AddCredits) }),
 		"update-key-page":      m.ExecuteWith(func() PL { return new(protocol.UpdateKeyPage) }),
 		"write-data":           m.ExecuteWith(func() PL { return new(protocol.WriteData) }),

--- a/internal/api/v2/pack.go
+++ b/internal/api/v2/pack.go
@@ -44,7 +44,7 @@ func packTxResponse(txid [32]byte, synth []byte, main *state.Transaction, pend *
 	}
 
 	switch payload := payload.(type) {
-	case *api.TokenTx:
+	case *api.SendTokens:
 		if len(res.SyntheticTxids) != len(payload.To) {
 			return nil, fmt.Errorf("not enough synthetic TXs: want %d, got %d", len(payload.To), len(res.SyntheticTxids))
 		}

--- a/internal/api/v2/unmarshal.go
+++ b/internal/api/v2/unmarshal.go
@@ -34,8 +34,8 @@ func unmarshalTxType(b []byte) types.TxType {
 func unmarshalTxPayload(b []byte) (protocol.TransactionPayload, error) {
 	var payload protocol.TransactionPayload
 	switch typ := unmarshalTxType(b); typ {
-	case types.TxTypeWithdrawTokens:
-		payload = new(api.TokenTx)
+	case types.TxTypeSendTokens:
+		payload = new(api.SendTokens)
 	case types.TxTypeSyntheticDepositTokens:
 		payload = new(synthetic.TokenTransactionDeposit)
 	case types.TxTypeCreateIdentity:

--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -24,7 +24,7 @@ func NewNodeExecutor(opts ExecutorOptions) (*Executor, error) {
 	case config.BlockValidator:
 		return newExecutor(opts,
 			CreateIdentity{},
-			WithdrawTokens{},
+			SendTokens{},
 			CreateTokenAccount{},
 			CreateDataAccount{},
 			AddCredits{},

--- a/internal/chain/send_tokens.go
+++ b/internal/chain/send_tokens.go
@@ -13,12 +13,12 @@ import (
 	"github.com/AccumulateNetwork/accumulate/types/synthetic"
 )
 
-type WithdrawTokens struct{}
+type SendTokens struct{}
 
-func (WithdrawTokens) Type() types.TxType { return types.TxTypeWithdrawTokens }
+func (SendTokens) Type() types.TxType { return types.TxTypeSendTokens }
 
-func (WithdrawTokens) Validate(st *StateManager, tx *transactions.GenTransaction) error {
-	body := new(api.TokenTx)
+func (SendTokens) Validate(st *StateManager, tx *transactions.GenTransaction) error {
+	body := new(api.SendTokens)
 	err := tx.As(body)
 	if err != nil {
 		return fmt.Errorf("invalid payload: %v", err)

--- a/internal/chain/send_tokens_test.go
+++ b/internal/chain/send_tokens_test.go
@@ -44,7 +44,7 @@ func TestLiteTokenTransactions(t *testing.T) {
 	st, err := NewStateManager(db.Begin(), gtx)
 	require.NoError(t, err)
 
-	err = WithdrawTokens{}.Validate(st, gtx)
+	err = SendTokens{}.Validate(st, gtx)
 	require.NoError(t, err)
 
 	//pull the chains again

--- a/internal/testing/load.go
+++ b/internal/testing/load.go
@@ -127,7 +127,7 @@ func BuildTestTokenTxGenTx(sponsor ed25519.PrivateKey, destAddr string, amount u
 	//use the public key of the bvc to make a sponsor address (this doesn't really matter right now, but need something so Identity of the BVC is good)
 	from := types.String(lite.GenerateAcmeAddress(sponsor.Public().(ed25519.PublicKey)))
 
-	tokenTx := apitypes.TokenTx{}
+	tokenTx := apitypes.SendTokens{}
 
 	tokenTx.From = types.UrlChain{String: from}
 	tokenTx.AddToAccount(types.String(destAddr), amount)

--- a/protocol/fee_schedule.go
+++ b/protocol/fee_schedule.go
@@ -23,8 +23,8 @@ const (
 	// FeeCreateTokenAccount $0.25
 	FeeCreateTokenAccount Fee = 2500
 
-	// FeeWithdrawTokens $0.03
-	FeeWithdrawTokens Fee = 300
+	// FeeSendTokens $0.03
+	FeeSendTokens Fee = 300
 
 	// FeeCreateDataAccount $.25
 	FeeCreateDataAccount Fee = 2500
@@ -38,13 +38,13 @@ const (
 	// FeeCreateToken $50.00
 	FeeCreateToken Fee = 500000
 
-	// FeeIssueTokens equiv. to token withdrawal @ $0.03
+	// FeeIssueTokens equiv. to token send @ $0.03
 	FeeIssueTokens Fee = 300
 
 	// FeeAcmeFaucet free
 	FeeAcmeFaucet Fee = 0
 
-	// FeeBurnTokens equiv. to token withdrawal
+	// FeeBurnTokens equiv. to token send
 	FeeBurnTokens Fee = 300
 
 	// FeeCreateKeyPage $1.00
@@ -76,8 +76,8 @@ func ComputeFee(tx *transactions.GenTransaction) (int, error) {
 		return FeeCreateIdentity.AsInt(), nil
 	case types.TxTypeCreateTokenAccount:
 		return FeeCreateTokenAccount.AsInt(), nil
-	case types.TxTypeWithdrawTokens:
-		return FeeWithdrawTokens.AsInt(), nil
+	case types.TxTypeSendTokens:
+		return FeeSendTokens.AsInt(), nil
 	case types.TxTypeCreateDataAccount:
 		return FeeCreateDataAccount.AsInt(), nil
 	case types.TxTypeWriteData:

--- a/types/api/APIRequests_test.go
+++ b/types/api/APIRequests_test.go
@@ -45,7 +45,7 @@ func createToken(tokenUrl string) (string, error) {
 }
 
 func createTokenTx(url string) (string, error) {
-	tx := &TokenTx{}
+	tx := &SendTokens{}
 	tx.From.String = types.String(url + "/MyAcmeTokens")
 	amt := uint64(1234)
 	tx.AddToAccount("redwagon/AcmeAccount", amt)

--- a/types/api/TokenTx_test.go
+++ b/types/api/TokenTx_test.go
@@ -19,7 +19,7 @@ func TestTokenTransaction(t *testing.T) {
 		t.Fatalf("Error marshalling TokenTransaction %v", err)
 	}
 
-	tt2 := TokenTx{}
+	tt2 := SendTokens{}
 	err = json.Unmarshal(data, &tt2)
 
 	if err != nil {
@@ -30,7 +30,7 @@ func TestTokenTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tt2 = TokenTx{}
+	tt2 = SendTokens{}
 	err = tt2.UnmarshalBinary(data)
 	if err != nil {
 		t.Fatal(err)

--- a/types/api/response/TokenTx.go
+++ b/types/api/response/TokenTx.go
@@ -25,7 +25,7 @@ type TokenTx struct {
 
 type TokenTxOutputStatus struct {
 	SyntheticTxId types.Bytes `json:"txid"`
-	api.TokenTxOutput
+	api.TokenRecipient
 }
 
 func (t *TokenTxOutputStatus) MarshalBinary() ([]byte, error) {
@@ -36,7 +36,7 @@ func (t *TokenTxOutputStatus) MarshalBinary() ([]byte, error) {
 	}
 	buffer.Write(data)
 
-	data, err = t.TokenTxOutput.MarshalBinary()
+	data, err = t.TokenRecipient.MarshalBinary()
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (t *TokenTxOutputStatus) UnmarshalBinary(data []byte) (err error) {
 	}
 	i := t.SyntheticTxId.Size(nil)
 
-	err = t.TokenTxOutput.UnmarshalBinary(data[i:])
+	err = t.TokenRecipient.UnmarshalBinary(data[i:])
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal AccountUrl from TokenTxAccountStatus, %v", err)
 	}

--- a/types/state/Transaction_test.go
+++ b/types/state/Transaction_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTransactionState(t *testing.T) {
-	nts1 := api.TokenTx{}
+	nts1 := api.SendTokens{}
 	nts1.From = types.UrlChain{String: "RedWagon/myAccount"}
 	nts1.AddToAccount("BlueWagon/account", uint64(100*100000000))
 

--- a/types/transaction_types.go
+++ b/types/transaction_types.go
@@ -34,9 +34,9 @@ const (
 	// synthetic chain create transaction.
 	TxTypeCreateTokenAccount TransactionType = 0x02
 
-	// TxTypeWithdrawTokens transfers tokens between token accounts, which
-	// produces a synthetic deposit tokens transaction.
-	TxTypeWithdrawTokens TransactionType = 0x03
+	// TxTypeSendTokens transfers tokens between token accounts, which produces
+	// a synthetic deposit tokens transaction.
+	TxTypeSendTokens TransactionType = 0x03
 
 	// TxTypeCreateDataAccount creates an ADI Data Account, which produces a
 	// synthetic chain create transaction.
@@ -134,8 +134,8 @@ func (t TransactionType) String() string {
 		return "createIdentity"
 	case TxTypeCreateTokenAccount:
 		return "createTokenAccount"
-	case TxTypeWithdrawTokens:
-		return "withdrawTokens"
+	case TxTypeSendTokens:
+		return "sendTokens"
 	case TxTypeCreateDataAccount:
 		return "createDataAccount"
 	case TxTypeWriteData:


### PR DESCRIPTION
For clarity. No functional changes, everything should still work the same, except the type for token transactions is now 'sendTokens'.