### PR TITLE
Rename sponsor to origin record

### DIFF
--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -162,7 +162,7 @@ func prepareGenTx(jsonPayload []byte, binaryPayload []byte, actor *url2.URL, si 
 	params.Tx.Signer = &acmeapi.Signer{}
 	params.Tx.Signer.PublicKey.FromBytes(privKey[32:])
 	params.Tx.Signer.Nonce = nonce
-	params.Tx.Sponsor = types.String(actor.String())
+	params.Tx.Origin = types.String(actor.String())
 	params.Tx.KeyPage = &acmeapi.APIRequestKeyPage{}
 	params.Tx.KeyPage.Height = si.KeyPageHeight
 	params.Tx.KeyPage.Index = si.KeyPageIndex
@@ -194,7 +194,7 @@ func prepareGenTxV2(jsonPayload, binaryPayload []byte, actor *url2.URL, si *tran
 	params.Payload = json.RawMessage(jsonPayload)
 	params.Signer.PublicKey = privKey[32:]
 	params.Signer.Nonce = nonce
-	params.Sponsor = actor.String()
+	params.Origin = actor.String()
 	params.KeyPage.Height = si.KeyPageHeight
 	params.KeyPage.Index = si.KeyPageIndex
 
@@ -486,7 +486,7 @@ func formatAmount(tokenUrl string, amount *big.Int) (string, error) {
 func printGeneralTransactionParameters(res *acmeapi.APIDataResponse) string {
 	out := fmt.Sprintf("---\n")
 	out += fmt.Sprintf("  - Transaction           : %x\n", res.TxId.AsBytes32())
-	out += fmt.Sprintf("  - Signer Url            : %s\n", res.Sponsor)
+	out += fmt.Sprintf("  - Signer Url            : %s\n", res.Origin)
 	out += fmt.Sprintf("  - Signature             : %x\n", res.Sig.Bytes())
 	if res.Signer != nil {
 		out += fmt.Sprintf("  - Signer Key            : %x\n", res.Signer.PublicKey.Bytes())
@@ -516,7 +516,7 @@ func PrintQueryResponseV2(v2 *api2.QueryResponse) (string, error) {
 			v1.MerkleState.Roots[i] = r
 		}
 	}
-	v1.Sponsor = types.String(v2.Sponsor)
+	v1.Origin = types.String(v2.Origin)
 	if v2.KeyPage != nil {
 		v1.KeyPage = new(acmeapi.APIRequestKeyPage)
 		v1.KeyPage.Height = v2.KeyPage.Height

--- a/internal/api/jsonrpc.go
+++ b/internal/api/jsonrpc.go
@@ -404,7 +404,7 @@ func (api *API) sendTx(req *acmeapi.APIRequestRaw, payload []byte) (*acmeapi.API
 	tx.Transaction = payload
 
 	tx.SigInfo = new(transactions.SignatureInfo)
-	tx.SigInfo.URL = string(req.Tx.Sponsor)
+	tx.SigInfo.URL = string(req.Tx.Origin)
 	tx.SigInfo.Nonce = req.Tx.Signer.Nonce
 	tx.SigInfo.KeyPageHeight = req.Tx.KeyPage.Height
 	tx.SigInfo.KeyPageIndex = req.Tx.KeyPage.Index

--- a/internal/api/unmarshal.go
+++ b/internal/api/unmarshal.go
@@ -134,7 +134,7 @@ func unmarshalTokenTx(txPayload []byte, txId types.Bytes, txSynthTxIds types.Byt
 	resp.Type = types.String(types.TxTypeSendTokens.Name())
 	resp.Data = new(json.RawMessage)
 	*resp.Data = data
-	resp.Sponsor = tx.From.String
+	resp.Origin = tx.From.String
 	return &resp, err
 }
 
@@ -150,7 +150,7 @@ func unmarshalSynthTokenDeposit(txPayload []byte, _ types.Bytes, txSynthTxIds ty
 		return nil, err
 	}
 
-	resp.Sponsor = tx.FromUrl
+	resp.Origin = tx.FromUrl
 	return resp, err
 }
 
@@ -215,8 +215,8 @@ func unmarshalTransaction(sigInfo *transactions.SignatureInfo, txPayload []byte,
 		return nil, err
 	}
 
-	if resp.Sponsor == "" {
-		resp.Sponsor = types.String(sigInfo.URL)
+	if resp.Origin == "" {
+		resp.Origin = types.String(sigInfo.URL)
 	}
 	return resp, err
 }

--- a/internal/api/v2/e2e_harness_test.go
+++ b/internal/api/v2/e2e_harness_test.go
@@ -129,7 +129,7 @@ func queryAs(t *testing.T, japi *api.JrpcMethods, method string, params, result 
 }
 
 type execParams struct {
-	Sponsor   string
+	Origin    string
 	Key       ed25519.PrivateKey
 	PageIndex uint64
 	Payload   protocol.TransactionPayload
@@ -147,11 +147,11 @@ func recode(t *testing.T, from, to interface{}) {
 func executeTx(t *testing.T, japi *api.JrpcMethods, method string, wait bool, params execParams) *api.TxResponse {
 	t.Helper()
 
-	qr := query(t, japi, "query", &api.UrlQuery{Url: params.Sponsor})
+	qr := query(t, japi, "query", &api.UrlQuery{Url: params.Origin})
 	now := time.Now()
 	nonce := uint64(now.Unix()*1e9) + uint64(now.Nanosecond())
 	tx, err := transactions.NewWith(&transactions.SignatureInfo{
-		URL:           params.Sponsor,
+		URL:           params.Origin,
 		KeyPageIndex:  params.PageIndex,
 		KeyPageHeight: qr.MerkleState.Count,
 		Nonce:         nonce,
@@ -162,7 +162,7 @@ func executeTx(t *testing.T, japi *api.JrpcMethods, method string, wait bool, pa
 	require.NoError(t, err)
 
 	req := new(api.TxRequest)
-	req.Sponsor = params.Sponsor
+	req.Origin = params.Origin
 	req.Signer.PublicKey = params.Key[32:]
 	req.Signer.Nonce = nonce
 	req.Signature = tx.Signature[0].Signature
@@ -214,7 +214,7 @@ func (d *e2eDUT) GetRecordHeight(url string) uint64 {
 func (d *e2eDUT) SubmitTxn(tx *transactions.GenTransaction) {
 	d.Require().NotEmpty(tx.Signature, "Transaction has no signatures")
 	pl := new(api.TxRequest)
-	pl.Sponsor = tx.SigInfo.URL
+	pl.Origin = tx.SigInfo.URL
 	pl.Signer.Nonce = tx.SigInfo.Nonce
 	pl.Signer.PublicKey = tx.Signature[0].PublicKey
 	pl.Signature = tx.Signature[0].Signature

--- a/internal/api/v2/e2e_test.go
+++ b/internal/api/v2/e2e_test.go
@@ -71,8 +71,8 @@ func TestValidate(t *testing.T) {
 
 	t.Run("Lite Account Credits", func(t *testing.T) {
 		executeTx(t, japi, "add-credits", true, execParams{
-			Sponsor: liteUrl.String(),
-			Key:     liteKey,
+			Origin: liteUrl.String(),
+			Key:    liteKey,
 			Payload: &AddCredits{
 				Recipient: liteUrl.String(),
 				Amount:    100,
@@ -93,8 +93,8 @@ func TestValidate(t *testing.T) {
 		adiKey = newKey([]byte(t.Name()))
 
 		executeTx(t, japi, "create-adi", true, execParams{
-			Sponsor: liteUrl.String(),
-			Key:     liteKey,
+			Origin: liteUrl.String(),
+			Key:    liteKey,
 			Payload: &IdentityCreate{
 				Url:         adiName,
 				PublicKey:   adiKey[32:],

--- a/internal/api/v2/execute_test.go
+++ b/internal/api/v2/execute_test.go
@@ -39,7 +39,7 @@ func testExecute(t *testing.T, j *JrpcMethods, count int) {
 	for i := 0; i < count; i++ {
 		req := new(TxRequest)
 		req.Payload = ""
-		req.Sponsor = fmt.Sprintf("test%d", i)
+		req.Origin = fmt.Sprintf("test%d", i)
 		go func() { ch <- j.DoExecute(context.Background(), req, []byte{}) }()
 	}
 
@@ -158,7 +158,7 @@ func TestDispatchExecuteQueueDuration(t *testing.T) {
 
 func TestExecuteCheckOnly(t *testing.T) {
 	baseReq := TxRequest{
-		Sponsor: "check",
+		Origin:  "check",
 		Payload: "",
 		Signer: Signer{
 			PublicKey: make([]byte, 32),

--- a/internal/api/v2/jrpc_execute.go
+++ b/internal/api/v2/jrpc_execute.go
@@ -76,7 +76,7 @@ func (m *JrpcMethods) Faucet(ctx context.Context, params json.RawMessage) interf
 	}
 
 	txrq := new(TxRequest)
-	txrq.Sponsor = tx.SigInfo.URL
+	txrq.Origin = tx.SigInfo.URL
 	txrq.Signer.Nonce = tx.SigInfo.Nonce
 	txrq.Signer.PublicKey = tx.Signature[0].PublicKey
 	txrq.KeyPage.Height = tx.SigInfo.KeyPageHeight
@@ -100,7 +100,7 @@ type executeRequest struct {
 
 // execute either executes the request locally, or dispatches it to another BVC
 func (m *JrpcMethods) execute(ctx context.Context, req *TxRequest, payload []byte) interface{} {
-	u, err := url.Parse(req.Sponsor)
+	u, err := url.Parse(req.Origin)
 	if err != nil {
 		return validatorError(err)
 	}
@@ -158,7 +158,7 @@ func (m *JrpcMethods) executeLocal(ctx context.Context, req *TxRequest, payload 
 	tx.Transaction = payload
 
 	tx.SigInfo = new(transactions.SignatureInfo)
-	tx.SigInfo.URL = req.Sponsor
+	tx.SigInfo.URL = req.Origin
 	tx.SigInfo.Nonce = req.Signer.Nonce
 	tx.SigInfo.KeyPageHeight = req.KeyPage.Height
 	tx.SigInfo.KeyPageIndex = req.KeyPage.Index

--- a/internal/api/v2/pack.go
+++ b/internal/api/v2/pack.go
@@ -49,7 +49,7 @@ func packTxResponse(txid [32]byte, synth []byte, main *state.Transaction, pend *
 			return nil, fmt.Errorf("not enough synthetic TXs: want %d, got %d", len(payload.To), len(res.SyntheticTxids))
 		}
 
-		res.Sponsor = tx.SigInfo.URL
+		res.Origin = tx.SigInfo.URL
 		data := new(TokenSend)
 		data.From = *payload.From.AsString()
 		data.To = make([]TokenDeposit, len(payload.To))
@@ -59,15 +59,15 @@ func packTxResponse(txid [32]byte, synth []byte, main *state.Transaction, pend *
 			data.To[i].Txid = synth[i*32 : (i+1)*32]
 		}
 
-		res.Sponsor = *payload.From.AsString()
+		res.Origin = *payload.From.AsString()
 		res.Data = data
 
 	case *synthetic.TokenTransactionDeposit:
-		res.Sponsor = *payload.FromUrl.AsString()
+		res.Origin = *payload.FromUrl.AsString()
 		res.Data = payload
 
 	default:
-		res.Sponsor = tx.SigInfo.URL
+		res.Origin = tx.SigInfo.URL
 		res.Data = payload
 	}
 

--- a/internal/api/v2/types.yml
+++ b/internal/api/v2/types.yml
@@ -10,8 +10,9 @@ QueryResponse:
       marshal-as: reference
     - name: Data
       type: any
-    - name: Sponsor
+    - name: Origin
       type: string
+      alternative: Sponsor
     - name: KeyPage
       type: KeyPage
       pointer: true
@@ -220,9 +221,10 @@ TxRequest:
   - name: CheckOnly
     type: bool
     optional: true
-  - name: Sponsor
+  - name: Origin
     type: string
     is-url: true
+    alternative: Sponsor
   - name: Signer
     type: Signer
     marshal-as: reference

--- a/internal/api/v2/types_gen.go
+++ b/internal/api/v2/types_gen.go
@@ -101,7 +101,7 @@ type QueryResponse struct {
 	Type           string       `json:"type,omitempty" form:"type" query:"type" validate:"required"`
 	MerkleState    *MerkleState `json:"merkleState,omitempty" form:"merkleState" query:"merkleState" validate:"required"`
 	Data           interface{}  `json:"data,omitempty" form:"data" query:"data" validate:"required"`
-	Sponsor        string       `json:"sponsor,omitempty" form:"sponsor" query:"sponsor" validate:"required"`
+	Origin         string       `json:"origin,omitempty" form:"origin" query:"origin" validate:"required"`
 	KeyPage        *KeyPage     `json:"keyPage,omitempty" form:"keyPage" query:"keyPage" validate:"required"`
 	Txid           []byte       `json:"txid,omitempty" form:"txid" query:"txid" validate:"required"`
 	Signer         *Signer      `json:"signer,omitempty" form:"signer" query:"signer" validate:"required"`
@@ -133,7 +133,7 @@ type TxHistoryQuery struct {
 
 type TxRequest struct {
 	CheckOnly bool        `json:"checkOnly,omitempty" form:"checkOnly" query:"checkOnly"`
-	Sponsor   string      `json:"sponsor,omitempty" form:"sponsor" query:"sponsor" validate:"required,acc-url"`
+	Origin    string      `json:"origin,omitempty" form:"origin" query:"origin" validate:"required,acc-url"`
 	Signer    Signer      `json:"signer,omitempty" form:"signer" query:"signer" validate:"required"`
 	Signature []byte      `json:"signature,omitempty" form:"signature" query:"signature" validate:"required"`
 	KeyPage   KeyPage     `json:"keyPage,omitempty" form:"keyPage" query:"keyPage" validate:"required"`
@@ -530,6 +530,7 @@ func (v *QueryResponse) MarshalJSON() ([]byte, error) {
 		Type           string       `json:"type,omitempty"`
 		MerkleState    *MerkleState `json:"merkleState,omitempty"`
 		Data           interface{}  `json:"data,omitempty"`
+		Origin         string       `json:"origin,omitempty"`
 		Sponsor        string       `json:"sponsor,omitempty"`
 		KeyPage        *KeyPage     `json:"keyPage,omitempty"`
 		Txid           *string      `json:"txid,omitempty"`
@@ -541,7 +542,8 @@ func (v *QueryResponse) MarshalJSON() ([]byte, error) {
 	u.Type = v.Type
 	u.MerkleState = v.MerkleState
 	u.Data = v.Data
-	u.Sponsor = v.Sponsor
+	u.Origin = v.Origin
+	u.Sponsor = v.Origin
 	u.KeyPage = v.KeyPage
 	u.Txid = encoding.BytesToJSON(v.Txid)
 	u.Signer = v.Signer
@@ -576,6 +578,7 @@ func (v *TokenDeposit) MarshalJSON() ([]byte, error) {
 func (v *TxRequest) MarshalJSON() ([]byte, error) {
 	u := struct {
 		CheckOnly bool        `json:"checkOnly,omitempty"`
+		Origin    string      `json:"origin,omitempty"`
 		Sponsor   string      `json:"sponsor,omitempty"`
 		Signer    Signer      `json:"signer,omitempty"`
 		Signature *string     `json:"signature,omitempty"`
@@ -583,7 +586,8 @@ func (v *TxRequest) MarshalJSON() ([]byte, error) {
 		Payload   interface{} `json:"payload,omitempty"`
 	}{}
 	u.CheckOnly = v.CheckOnly
-	u.Sponsor = v.Sponsor
+	u.Origin = v.Origin
+	u.Sponsor = v.Origin
 	u.Signer = v.Signer
 	u.Signature = encoding.BytesToJSON(v.Signature)
 	u.KeyPage = v.KeyPage
@@ -768,6 +772,7 @@ func (v *QueryResponse) UnmarshalJSON(data []byte) error {
 		Type           string       `json:"type,omitempty"`
 		MerkleState    *MerkleState `json:"merkleState,omitempty"`
 		Data           interface{}  `json:"data,omitempty"`
+		Origin         string       `json:"origin,omitempty"`
 		Sponsor        string       `json:"sponsor,omitempty"`
 		KeyPage        *KeyPage     `json:"keyPage,omitempty"`
 		Txid           *string      `json:"txid,omitempty"`
@@ -779,7 +784,8 @@ func (v *QueryResponse) UnmarshalJSON(data []byte) error {
 	u.Type = v.Type
 	u.MerkleState = v.MerkleState
 	u.Data = v.Data
-	u.Sponsor = v.Sponsor
+	u.Origin = v.Origin
+	u.Sponsor = v.Origin
 	u.KeyPage = v.KeyPage
 	u.Txid = encoding.BytesToJSON(v.Txid)
 	u.Signer = v.Signer
@@ -792,7 +798,12 @@ func (v *QueryResponse) UnmarshalJSON(data []byte) error {
 	v.Type = u.Type
 	v.MerkleState = u.MerkleState
 	v.Data = u.Data
-	v.Sponsor = u.Sponsor
+	var zeroOrigin string
+	if u.Origin != zeroOrigin {
+		v.Origin = u.Origin
+	} else {
+		v.Origin = u.Sponsor
+	}
 	v.KeyPage = u.KeyPage
 	if x, err := encoding.BytesFromJSON(u.Txid); err != nil {
 		return fmt.Errorf("error decoding Txid: %w", err)
@@ -858,6 +869,7 @@ func (v *TokenDeposit) UnmarshalJSON(data []byte) error {
 func (v *TxRequest) UnmarshalJSON(data []byte) error {
 	u := struct {
 		CheckOnly bool        `json:"checkOnly,omitempty"`
+		Origin    string      `json:"origin,omitempty"`
 		Sponsor   string      `json:"sponsor,omitempty"`
 		Signer    Signer      `json:"signer,omitempty"`
 		Signature *string     `json:"signature,omitempty"`
@@ -865,7 +877,8 @@ func (v *TxRequest) UnmarshalJSON(data []byte) error {
 		Payload   interface{} `json:"payload,omitempty"`
 	}{}
 	u.CheckOnly = v.CheckOnly
-	u.Sponsor = v.Sponsor
+	u.Origin = v.Origin
+	u.Sponsor = v.Origin
 	u.Signer = v.Signer
 	u.Signature = encoding.BytesToJSON(v.Signature)
 	u.KeyPage = v.KeyPage
@@ -874,7 +887,12 @@ func (v *TxRequest) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	v.CheckOnly = u.CheckOnly
-	v.Sponsor = u.Sponsor
+	var zeroOrigin string
+	if u.Origin != zeroOrigin {
+		v.Origin = u.Origin
+	} else {
+		v.Origin = u.Sponsor
+	}
 	v.Signer = u.Signer
 	if x, err := encoding.BytesFromJSON(u.Signature); err != nil {
 		return fmt.Errorf("error decoding Signature: %w", err)

--- a/internal/chain/README.md
+++ b/internal/chain/README.md
@@ -4,11 +4,11 @@ Chain validators are organized by transaction type. The executor handles mundane
 tasks that are common to all chain validators, such as authentication and
 authorization.
 
-In general, every transaction requires a sponsor. Thus, the executor validates
-and loads the sponsor before delegating to the chain validator. However, certain
-transaction types, specifically synthetic transactions that create records, may
-not need an extant sponsor. The executor has a specific clause for these special
-cases.
+In general, every transaction requires an origin record. Thus, the executor
+validates and loads the origin before delegating to the chain validator.
+However, certain transaction types, specifically synthetic transactions that
+create records, may not need an extant origin. The executor has a specific
+clause for these special cases.
 
 ## Chain Validator Implementation
 

--- a/internal/chain/add_credits.go
+++ b/internal/chain/add_credits.go
@@ -47,7 +47,7 @@ func (AddCredits) Validate(st *StateManager, tx *transactions.GenTransaction) er
 		}
 	} else if errors.Is(err, storage.ErrNotFound) {
 		if recvUrl.Routing() == tx.Routing {
-			// If the recipient and the sponsor have the same routing number,
+			// If the recipient and the origin have the same routing number,
 			// they must be on the same BVC. Thus in that case, failing to
 			// locate the recipient chain means it doesn't exist.
 			return fmt.Errorf("invalid recipient: not found")
@@ -57,11 +57,11 @@ func (AddCredits) Validate(st *StateManager, tx *transactions.GenTransaction) er
 	}
 
 	var account tokenChain
-	switch sponsor := st.Sponsor.(type) {
+	switch origin := st.Origin.(type) {
 	case *protocol.LiteTokenAccount:
-		account = sponsor
+		account = origin
 	case *state.TokenAccount:
-		account = sponsor
+		account = origin
 	default:
 		return fmt.Errorf("not an account: %q", tx.SigInfo.URL)
 	}

--- a/internal/chain/create_data_account.go
+++ b/internal/chain/create_data_account.go
@@ -26,8 +26,8 @@ func (CreateDataAccount) Validate(st *StateManager, tx *transactions.GenTransact
 	}
 
 	//only the ADI can create the data account associated with the ADI
-	if !dataAccountUrl.Identity().Equal(st.SponsorUrl) {
-		return fmt.Errorf("%q cannot sponsor %q", st.SponsorUrl, dataAccountUrl)
+	if !dataAccountUrl.Identity().Equal(st.OriginUrl) {
+		return fmt.Errorf("%q cannot be the origininator of %q", st.OriginUrl, dataAccountUrl)
 	}
 
 	//create the data account
@@ -45,7 +45,7 @@ func (CreateDataAccount) Validate(st *StateManager, tx *transactions.GenTransact
 
 	//setup key book associated with account
 	if body.KeyBookUrl == "" {
-		account.KeyBook = st.Sponsor.Header().KeyBook
+		account.KeyBook = st.Origin.Header().KeyBook
 	} else {
 		keyBookUrl, err := url.Parse(body.KeyBookUrl)
 		if err != nil {

--- a/internal/chain/create_identity.go
+++ b/internal/chain/create_identity.go
@@ -32,11 +32,11 @@ func (CreateIdentity) Validate(st *StateManager, tx *transactions.GenTransaction
 		return fmt.Errorf("invalid URL: %v", err)
 	}
 
-	switch st.Sponsor.(type) {
+	switch st.Origin.(type) {
 	case *protocol.LiteTokenAccount, *state.AdiState:
 		// OK
 	default:
-		return fmt.Errorf("chain type %d cannot sponsor ADIs", st.Sponsor.Header().Type)
+		return fmt.Errorf("chain type %d cannot be the origininator of ADIs", st.Origin.Header().Type)
 	}
 
 	var pageUrl, bookUrl *url.URL

--- a/internal/chain/create_key_book.go
+++ b/internal/chain/create_key_book.go
@@ -15,8 +15,8 @@ type CreateKeyBook struct{}
 func (CreateKeyBook) Type() types.TxType { return types.TxTypeCreateKeyBook }
 
 func (CreateKeyBook) Validate(st *StateManager, tx *transactions.GenTransaction) error {
-	if _, ok := st.Sponsor.(*state.AdiState); !ok {
-		return fmt.Errorf("invalid sponsor: want chain type %v, got %v", types.ChainTypeIdentity, st.Sponsor.Header().Type)
+	if _, ok := st.Origin.(*state.AdiState); !ok {
+		return fmt.Errorf("invalid origin record: want chain type %v, got %v", types.ChainTypeIdentity, st.Origin.Header().Type)
 	}
 
 	body := new(protocol.CreateKeyBook)
@@ -34,8 +34,8 @@ func (CreateKeyBook) Validate(st *StateManager, tx *transactions.GenTransaction)
 		return fmt.Errorf("invalid target URL: %v", err)
 	}
 
-	if !sgUrl.Identity().Equal(st.SponsorUrl) {
-		return fmt.Errorf("%q does not belong to %q", sgUrl, st.SponsorUrl)
+	if !sgUrl.Identity().Equal(st.OriginUrl) {
+		return fmt.Errorf("%q does not belong to %q", sgUrl, st.OriginUrl)
 	}
 
 	entries := make([]*protocol.KeyPage, len(body.Pages))
@@ -52,8 +52,8 @@ func (CreateKeyBook) Validate(st *StateManager, tx *transactions.GenTransaction)
 			return fmt.Errorf("invalid sig spec state: bad URL: %v", err)
 		}
 
-		if !u.Identity().Equal(st.SponsorUrl) {
-			return fmt.Errorf("%q does not belong to %q", u, st.SponsorUrl)
+		if !u.Identity().Equal(st.OriginUrl) {
+			return fmt.Errorf("%q does not belong to %q", u, st.OriginUrl)
 		}
 
 		if (entry.KeyBook != types.Bytes32{}) {
@@ -65,7 +65,7 @@ func (CreateKeyBook) Validate(st *StateManager, tx *transactions.GenTransaction)
 
 	scc := new(protocol.SyntheticCreateChain)
 	scc.Cause = types.Bytes(tx.TransactionHash()).AsBytes32()
-	st.Submit(st.SponsorUrl, scc)
+	st.Submit(st.OriginUrl, scc)
 
 	ssg := protocol.NewKeyBook()
 	ssg.ChainUrl = types.String(sgUrl.String())

--- a/internal/chain/create_key_page.go
+++ b/internal/chain/create_key_page.go
@@ -16,13 +16,13 @@ func (CreateKeyPage) Type() types.TxType { return types.TxTypeCreateKeyPage }
 
 func (CreateKeyPage) Validate(st *StateManager, tx *transactions.GenTransaction) error {
 	var group *protocol.KeyBook
-	switch sponsor := st.Sponsor.(type) {
+	switch origin := st.Origin.(type) {
 	case *state.AdiState:
 		// Create an unbound sig spec
 	case *protocol.KeyBook:
-		group = sponsor
+		group = origin
 	default:
-		return fmt.Errorf("invalid sponsor: want chain type %v or %v, got %v", types.ChainTypeIdentity, types.ChainTypeKeyBook, sponsor.Header().Type)
+		return fmt.Errorf("invalid origin record: want chain type %v or %v, got %v", types.ChainTypeIdentity, types.ChainTypeKeyBook, origin.Header().Type)
 	}
 
 	body := new(protocol.CreateKeyPage)
@@ -40,13 +40,13 @@ func (CreateKeyPage) Validate(st *StateManager, tx *transactions.GenTransaction)
 		return fmt.Errorf("invalid target URL: %v", err)
 	}
 
-	if !msUrl.Identity().Equal(st.SponsorUrl.Identity()) {
-		return fmt.Errorf("%q does not belong to %q", msUrl, st.SponsorUrl)
+	if !msUrl.Identity().Equal(st.OriginUrl.Identity()) {
+		return fmt.Errorf("%q does not belong to %q", msUrl, st.OriginUrl)
 	}
 
 	scc := new(protocol.SyntheticCreateChain)
 	scc.Cause = types.Bytes(tx.TransactionHash()).AsBytes32()
-	st.Submit(st.SponsorUrl, scc)
+	st.Submit(st.OriginUrl, scc)
 
 	spec := protocol.NewKeyPage()
 	spec.ChainUrl = types.String(msUrl.String())
@@ -56,7 +56,7 @@ func (CreateKeyPage) Validate(st *StateManager, tx *transactions.GenTransaction)
 		if err != nil {
 			// Failing here would require writing an invalid URL to the state.
 			// But stuff happens, so don't panic.
-			return fmt.Errorf("invalid sponsor URL: %v", err)
+			return fmt.Errorf("invalid origin record URL: %v", err)
 		}
 
 		group.Pages = append(group.Pages, types.Bytes(msUrl.ResourceChain()).AsBytes32())

--- a/internal/chain/create_token_account.go
+++ b/internal/chain/create_token_account.go
@@ -32,13 +32,13 @@ func (CreateTokenAccount) Validate(st *StateManager, tx *transactions.GenTransac
 	}
 	// TODO Make sure tokenUrl is a real kind of token
 
-	if !accountUrl.Identity().Equal(st.SponsorUrl) {
-		return fmt.Errorf("%q cannot sponsor %q", st.SponsorUrl, accountUrl)
+	if !accountUrl.Identity().Equal(st.OriginUrl) {
+		return fmt.Errorf("%q cannot be the origininator of %q", st.OriginUrl, accountUrl)
 	}
 
 	account := state.NewTokenAccount(accountUrl.String(), tokenUrl.String())
 	if body.KeyBookUrl == "" {
-		account.KeyBook = st.Sponsor.Header().KeyBook
+		account.KeyBook = st.Origin.Header().KeyBook
 	} else {
 		keyBookUrl, err := url.Parse(body.KeyBookUrl)
 		if err != nil {

--- a/internal/chain/executor.go
+++ b/internal/chain/executor.go
@@ -296,9 +296,9 @@ func (m *Executor) check(tx *transactions.GenTransaction) (*StateManager, error)
 	if errors.Is(err, storage.ErrNotFound) {
 		switch txt {
 		case types.TxTypeSyntheticCreateChain, types.TxTypeSyntheticDepositTokens:
-			// TX does not require a sponsor - it may create the sponsor
+			// TX does not require an origin - it may create the origin
 		default:
-			return nil, fmt.Errorf("sponsor not found: %v", err)
+			return nil, fmt.Errorf("origin record not found: %v", err)
 		}
 	} else if err != nil {
 		return nil, err
@@ -310,26 +310,26 @@ func (m *Executor) check(tx *transactions.GenTransaction) (*StateManager, error)
 	}
 
 	book := new(protocol.KeyBook)
-	switch sponsor := st.Sponsor.(type) {
+	switch origin := st.Origin.(type) {
 	case *protocol.LiteTokenAccount:
-		return st, m.checkLite(st, tx, sponsor)
+		return st, m.checkLite(st, tx, origin)
 
 	case *state.AdiState, *state.TokenAccount, *protocol.KeyPage, *protocol.DataAccount:
-		if (sponsor.Header().KeyBook == types.Bytes32{}) {
-			return nil, fmt.Errorf("sponsor has not been assigned to an SSG")
+		if (origin.Header().KeyBook == types.Bytes32{}) {
+			return nil, fmt.Errorf("origin record has not been assigned to an SSG")
 		}
-		err := st.LoadAs(sponsor.Header().KeyBook, book)
+		err := st.LoadAs(origin.Header().KeyBook, book)
 		if err != nil {
 			return nil, fmt.Errorf("invalid KeyBook: %v", err)
 		}
 
 	case *protocol.KeyBook:
-		book = sponsor
+		book = origin
 
 	default:
-		// The TX sponsor cannot be a transaction
+		// The TX origin cannot be a transaction
 		// Token issue chains are not implemented
-		return nil, fmt.Errorf("invalid sponsor: chain type %v cannot sponsor transactions", sponsor.Header().Type)
+		return nil, fmt.Errorf("invalid origin record: chain type %v cannot be the origininator of transactions", origin.Header().Type)
 	}
 
 	if tx.SigInfo.KeyPageIndex >= uint64(len(book.Pages)) {
@@ -394,7 +394,7 @@ func (m *Executor) checkLite(st *StateManager, tx *transactions.GenTransaction, 
 	if err != nil {
 		// This shouldn't happen because invalid URLs should never make it
 		// into the database.
-		return fmt.Errorf("invalid sponsor URL: %v", err)
+		return fmt.Errorf("invalid origin record URL: %v", err)
 	}
 
 	urlKH, _, err := protocol.ParseLiteAddress(u)
@@ -407,7 +407,7 @@ func (m *Executor) checkLite(st *StateManager, tx *transactions.GenTransaction, 
 	for i, sig := range tx.Signature {
 		sigKH := sha256.Sum256(sig.PublicKey)
 		if !bytes.Equal(urlKH, sigKH[:20]) {
-			return fmt.Errorf("signature %d's public key does not match the sponsor", i)
+			return fmt.Errorf("signature %d's public key does not match the origin record", i)
 		}
 
 		switch {

--- a/internal/chain/send_tokens_test.go
+++ b/internal/chain/send_tokens_test.go
@@ -49,11 +49,11 @@ func TestLiteTokenTransactions(t *testing.T) {
 
 	//pull the chains again
 	tas := new(protocol.LiteTokenAccount)
-	require.NoError(t, st.LoadAs(st.SponsorChainId, tas))
+	require.NoError(t, st.LoadAs(st.OriginChainId, tas))
 	require.Equal(t, tokenUrl, types.String(tas.TokenUrl), "token url of state doesn't match expected")
 	require.Equal(t, uint64(2), tas.TxCount, "expected a token transaction count of 2")
 
-	refUrl := st.SponsorUrl.JoinPath(fmt.Sprint(tas.TxCount - 1))
+	refUrl := st.OriginUrl.JoinPath(fmt.Sprint(tas.TxCount - 1))
 	txRef := new(state.TxReference)
 	require.NoError(t, st.LoadUrlAs(refUrl, txRef))
 	require.Equal(t, types.String(refUrl.String()), txRef.ChainUrl, "chain header expected transaction reference")

--- a/internal/chain/state.go
+++ b/internal/chain/state.go
@@ -29,9 +29,9 @@ type StateManager struct {
 	synthSigs   []*state.SyntheticSignature
 	logger      log.Logger
 
-	Sponsor        state.Chain
-	SponsorUrl     *url.URL
-	SponsorChainId [32]byte
+	Origin        state.Chain
+	OriginUrl     *url.URL
+	OriginChainId [32]byte
 }
 
 type storeKind int
@@ -56,7 +56,7 @@ type storeDataEntry struct {
 }
 
 // NewStateManager creates a new state manager and loads the transaction's
-// sponsor. If the sponsor is not found, NewStateManager returns a valid state
+// origin. If the origin is not found, NewStateManager returns a valid state
 // manager along with a not-found error.
 func NewStateManager(dbTx *state.DBTransaction, tx *transactions.GenTransaction) (*StateManager, error) {
 	m := new(StateManager)
@@ -68,23 +68,23 @@ func NewStateManager(dbTx *state.DBTransaction, tx *transactions.GenTransaction)
 	m.txHash = types.Bytes(tx.TransactionHash()).AsBytes32()
 	m.txType = tx.TransactionType()
 
-	// The sponsor URL must be valid
+	// The origin URL must be valid
 	var err error
-	m.SponsorUrl, err = url.Parse(tx.SigInfo.URL)
+	m.OriginUrl, err = url.Parse(tx.SigInfo.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	// Find the sponsor
-	copy(m.SponsorChainId[:], m.SponsorUrl.ResourceChain())
-	m.Sponsor, err = m.Load(m.SponsorChainId)
+	// Find the origin
+	copy(m.OriginChainId[:], m.OriginUrl.ResourceChain())
+	m.Origin, err = m.Load(m.OriginChainId)
 	if err == nil {
 		return m, nil
 	}
 
-	// If the sponsor doesn't exist, that might be OK
+	// If the origin doesn't exist, that might be OK
 	if errors.Is(err, storage.ErrNotFound) {
-		return m, fmt.Errorf("sponsor %q %w", m.SponsorUrl, err)
+		return m, fmt.Errorf("invalid origin record: %q %w", m.OriginUrl, storage.ErrNotFound)
 	}
 	return nil, err
 }

--- a/internal/chain/synthetic_anchor.go
+++ b/internal/chain/synthetic_anchor.go
@@ -17,10 +17,10 @@ type SyntheticAnchor struct {
 func (SyntheticAnchor) Type() types.TxType { return types.TxTypeSyntheticAnchor }
 
 func (x SyntheticAnchor) Validate(st *StateManager, tx *transactions.GenTransaction) error {
-	// Verify that the sponsor is the node
+	// Verify that the origin is the node
 	nodeUrl := x.Network.NodeUrl()
-	if !st.SponsorUrl.Equal(nodeUrl) {
-		return fmt.Errorf("invalid sponsor: %q != %q", st.SponsorUrl, nodeUrl)
+	if !st.OriginUrl.Equal(nodeUrl) {
+		return fmt.Errorf("invalid origin record: %q != %q", st.OriginUrl, nodeUrl)
 	}
 
 	// Unpack the payload

--- a/internal/chain/synthetic_deposit_credits.go
+++ b/internal/chain/synthetic_deposit_credits.go
@@ -20,15 +20,15 @@ func (SyntheticDepositCredits) Validate(st *StateManager, tx *transactions.GenTr
 	}
 
 	var account creditChain
-	switch sponsor := st.Sponsor.(type) {
+	switch origin := st.Origin.(type) {
 	case *protocol.LiteTokenAccount:
-		account = sponsor
+		account = origin
 
 	case *protocol.KeyPage:
-		account = sponsor
+		account = origin
 
 	default:
-		return fmt.Errorf("invalid sponsor: want chain type %v or %v, got %v", types.ChainTypeLiteTokenAccount, types.ChainTypeKeyPage, st.Sponsor.Header().Type)
+		return fmt.Errorf("invalid origin record: want chain type %v or %v, got %v", types.ChainTypeLiteTokenAccount, types.ChainTypeKeyPage, st.Origin.Header().Type)
 	}
 
 	account.CreditCredits(body.Amount)

--- a/internal/chain/synthetic_token_deposit.go
+++ b/internal/chain/synthetic_token_deposit.go
@@ -26,7 +26,7 @@ func (SyntheticTokenDeposit) Validate(st *StateManager, tx *transactions.GenTran
 	}
 
 	if body.ToUrl != types.String(tx.SigInfo.URL) {
-		return fmt.Errorf("deposit destination does not match TX sponsor")
+		return fmt.Errorf("deposit destination does not match transaction origin record")
 	}
 
 	accountUrl, err := url.Parse(tx.SigInfo.URL)
@@ -40,14 +40,14 @@ func (SyntheticTokenDeposit) Validate(st *StateManager, tx *transactions.GenTran
 	}
 
 	var account tokenChain
-	if st.Sponsor != nil {
-		switch sponsor := st.Sponsor.(type) {
+	if st.Origin != nil {
+		switch origin := st.Origin.(type) {
 		case *protocol.LiteTokenAccount:
-			account = sponsor
+			account = origin
 		case *state.TokenAccount:
-			account = sponsor
+			account = origin
 		default:
-			return fmt.Errorf("invalid sponsor: want chain type %v or %v, got %v", types.ChainTypeLiteTokenAccount, types.ChainTypeTokenAccount, sponsor.Header().Type)
+			return fmt.Errorf("invalid origin record: want chain type %v or %v, got %v", types.ChainTypeLiteTokenAccount, types.ChainTypeTokenAccount, origin.Header().Type)
 		}
 	} else if keyHash, tok, err := protocol.ParseLiteAddress(accountUrl); err != nil {
 		return fmt.Errorf("invalid lite token account URL: %v", err)

--- a/internal/chain/synthetic_token_deposit_test.go
+++ b/internal/chain/synthetic_token_deposit_test.go
@@ -33,14 +33,14 @@ func TestSynthTokenDeposit_Lite(t *testing.T) {
 
 	//try to extract the state to see if we have a valid account
 	tas := new(protocol.LiteTokenAccount)
-	require.NoError(t, st.LoadAs(st.SponsorChainId, tas))
+	require.NoError(t, st.LoadAs(st.OriginChainId, tas))
 	require.Equal(t, types.String(gtx.SigInfo.URL), tas.ChainUrl, "invalid chain header")
 	require.Equalf(t, types.ChainTypeLiteTokenAccount, tas.Type, "chain state is not a lite account, it is %s", tas.ChainHeader.Type.Name())
 	require.Equal(t, tokenUrl, tas.TokenUrl, "token url of state doesn't match expected")
 	require.Equal(t, uint64(1), tas.TxCount)
 
 	//now query the tx reference
-	refUrl := st.SponsorUrl.JoinPath(fmt.Sprint(tas.TxCount - 1))
+	refUrl := st.OriginUrl.JoinPath(fmt.Sprint(tas.TxCount - 1))
 	txRef := new(state.TxReference)
 	require.NoError(t, st.LoadUrlAs(refUrl, txRef))
 	require.Equal(t, types.String(refUrl.String()), txRef.ChainUrl, "chain header expected transaction reference")

--- a/internal/chain/update_key_page.go
+++ b/internal/chain/update_key_page.go
@@ -22,9 +22,9 @@ func (UpdateKeyPage) Validate(st *StateManager, tx *transactions.GenTransaction)
 		return fmt.Errorf("invalid payload: %v", err)
 	}
 
-	page, ok := st.Sponsor.(*protocol.KeyPage)
+	page, ok := st.Origin.(*protocol.KeyPage)
 	if !ok {
-		return fmt.Errorf("invalid sponsor: want chain type %v, got %v", types.ChainTypeKeyPage, st.Sponsor.Header().Type)
+		return fmt.Errorf("invalid origin record: want chain type %v, got %v", types.ChainTypeKeyPage, st.Origin.Header().Type)
 	}
 
 	// We're changing the height of the key page, so reset all the nonces
@@ -56,17 +56,17 @@ func (UpdateKeyPage) Validate(st *StateManager, tx *transactions.GenTransaction)
 		}
 
 		for i, p := range ssg.Pages {
-			if p == st.SponsorChainId {
+			if p == st.OriginChainId {
 				priority = i
 			}
 		}
 		if priority < 0 {
-			return fmt.Errorf("cannot find %q in key book with ID %X", st.SponsorUrl, page.KeyBook)
+			return fmt.Errorf("cannot find %q in key book with ID %X", st.OriginUrl, page.KeyBook)
 		}
 
 		// 0 is the highest priority, followed by 1, etc
 		if tx.SigInfo.KeyPageIndex > uint64(priority) {
-			return fmt.Errorf("cannot modify %q with a lower priority key page", st.SponsorUrl)
+			return fmt.Errorf("cannot modify %q with a lower priority key page", st.OriginUrl)
 		}
 	}
 

--- a/internal/chain/write_data.go
+++ b/internal/chain/write_data.go
@@ -19,9 +19,9 @@ func (WriteData) Validate(st *StateManager, tx *transactions.GenTransaction) err
 		return fmt.Errorf("invalid payload: %v", err)
 	}
 
-	if st.Sponsor.Header().Type != types.ChainTypeDataAccount {
-		return fmt.Errorf("sponsor is not a data account: want %v, got %v",
-			types.ChainTypeDataAccount, st.Sponsor.Header().Type)
+	if st.Origin.Header().Type != types.ChainTypeDataAccount {
+		return fmt.Errorf("invalid origin record: want %v, got %v",
+			types.ChainTypeDataAccount, st.Origin.Header().Type)
 	}
 
 	//check will return error if there is too much data or no data for the entry
@@ -42,7 +42,7 @@ func (WriteData) Validate(st *StateManager, tx *transactions.GenTransaction) err
 
 	sw := protocol.SegWitDataEntry{}
 	copy(sw.EntryHash[:], body.Entry.Hash())
-	sw.EntryUrl = st.Sponsor.Header().GetChainUrl()
+	sw.EntryUrl = st.Origin.Header().GetChainUrl()
 
 	segWitPayload, err := sw.MarshalBinary()
 	if err != nil {
@@ -57,7 +57,7 @@ func (WriteData) Validate(st *StateManager, tx *transactions.GenTransaction) err
 	//now replace the original data entry payload with the new segwit payload
 	tx.Transaction = segWitPayload
 
-	st.UpdateData(st.Sponsor, sw.EntryHash[:], dataPayload)
+	st.UpdateData(st.Origin, sw.EntryHash[:], dataPayload)
 
 	return nil
 }

--- a/types/api/APIRequests.go
+++ b/types/api/APIRequests.go
@@ -27,7 +27,7 @@ type APIRequestRaw struct {
 // concatenation of ( sha256(Signer.URL) | Data | Timestamp ).  The txid is the sha256(ledger)
 // and the signature is ed25519( ledger )
 type APIRequestRawTx struct {
-	Sponsor types.String       `json:"sponsor" form:"sponsor" query:"sponsor" validate:"required"`
+	Origin  types.String       `json:"sponsor" form:"sponsor" query:"sponsor" validate:"required"` // retain 'sponsor' for backwards compatability
 	Data    *json.RawMessage   `json:"data" form:"data" query:"data" validate:"required"`
 	Signer  *Signer            `json:"signer" form:"signer" query:"signer" validate:"required"`
 	Sig     types.Bytes64      `json:"sig" form:"sig" query:"sig" validate:"required"`
@@ -72,7 +72,7 @@ type APIDataResponse struct {
 	Type        types.String       `json:"type" form:"type" query:"type" validate:"oneof:adi,token,tokenAccount,tokenTx,tx,keyPage,keyBook,assignKeyPage,addCredits,directory,version"`
 	MerkleState *MerkleState       `json:"merkleState,omitempty" form:"merkleState" query:"merkleState"`
 	Data        *json.RawMessage   `json:"data" form:"data" query:"data"`
-	Sponsor     types.String       `json:"sponsor" form:"sponsor" query:"sponsor" validate:"required"`
+	Origin      types.String       `json:"sponsor" form:"sponsor" query:"sponsor" validate:"required"` // retain 'sponsor' for backwards compatability
 	KeyPage     *APIRequestKeyPage `json:"keyPage" form:"keyPage" query:"keyPage" validate:"required"`
 	TxId        *types.Bytes       `json:"txid" form:"txid" query:"txid"`
 	//the following are optional available only if pending chain has not been purged

--- a/types/api/APIRequests_test.go
+++ b/types/api/APIRequests_test.go
@@ -65,7 +65,7 @@ func createRequest(t *testing.T, adiUrl string, kp *ed25519.PrivKey, message str
 	req.Tx.Data = &raw
 	req.Tx.Signer = &Signer{}
 	req.Tx.Signer.Nonce = uint64(time.Now().Unix())
-	req.Tx.Sponsor = types.String(adiUrl)
+	req.Tx.Origin = types.String(adiUrl)
 	req.Tx.KeyPage = &APIRequestKeyPage{}
 	req.Tx.KeyPage.Height = 1
 	copy(req.Tx.Signer.PublicKey[:], kp.PubKey().Bytes())

--- a/types/api/transactions/gentransaction.go
+++ b/types/api/transactions/gentransaction.go
@@ -138,7 +138,7 @@ func (t *GenTransaction) SetRoutingChainID() error { //
 	}
 	u, err := url.Parse(t.SigInfo.URL)
 	if err != nil {
-		return fmt.Errorf("invalid sponsor: %w", err)
+		return fmt.Errorf("invalid origin record: %w", err)
 	}
 	// TODO this should use u.Routing()
 	h := u.IdentityChain()                                               // Hash the identity


### PR DESCRIPTION
Sponsor is unnecessarily confusing. Origin record isn't perfect, but it's much better. I thought about 'actor', but that would make it hard to come up with an equivalent to "the transaction is sponsored/authored by X".