### PR TITLE
CI test reports

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,13 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -cpu=4 -count=1 -v ./...
+        run: go run gotest.tools/gotestsum --junitfile report.xml --format testname -- -cpu 4 ./...
+
+      - name: Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report-linux
+          path: report.xml
 
   cli-test:
     name: CLI Integration Test
@@ -116,7 +122,13 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go run gotest.tools/gotestsum --junitfile report.xml --format testname -- -cpu 4 ./...
+
+      - name: Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report-windows
+          path: report.xml
 
   build-macos:
     name: Build macOS
@@ -147,4 +159,10 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go run gotest.tools/gotestsum --junitfile report.xml --format testname -- -cpu 4 ./...
+
+      - name: Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report-macos
+          path: report.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,9 +30,13 @@ stages:
   extends: .go
   needs: []
   tags: [docker, linux]
+  artifacts:
+    when: always
+    reports:
+      junit: report.xml
   script:
   - go build -v ./...
-  - go test -v -cpu=4 -count=1 ./...
+  - go run gotest.tools/gotestsum --junitfile report.xml --format testname -- -cpu 4 ./...
 
 test 1/2:
   extends: .test

--- a/cmd/cli/cmd/root_test.go
+++ b/cmd/cli/cmd/root_test.go
@@ -31,14 +31,8 @@ type testMatrixTests []testCase
 var testMatrix testMatrixTests
 
 func TestCli(t *testing.T) {
-	switch {
-	case testing.Short():
-		t.Skip("Skipping test in short mode")
-	case runtime.GOOS == "windows":
-		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
-	case runtime.GOOS == "darwin" && os.Getenv("CI") == "true":
-		t.Skip("This test is flaky in macOS CI")
-	}
+	acctesting.SkipLong(t)
+	acctesting.SkipPlatformCI(t, "darwin", "flaky")
 
 	tc := &testCmd{}
 	tc.initalize(t)

--- a/debug/faucet_test.go
+++ b/debug/faucet_test.go
@@ -1,21 +1,18 @@
 package debug_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/AccumulateNetwork/accumulate/internal/api"
 	"github.com/AccumulateNetwork/accumulate/internal/relay"
+	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDebugFaucet(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("This is a test made for debugging. It is not intended for use except for as a debugging tool.")
-	}
-
+	acctesting.SkipCI(t, "intended for debugging only")
 	t.Skip("Skip this test unless you need it to debug something")
 
 	// Networks must be in the same order as they are passed to --relay-to in the node configuration

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.7
-	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools/gotestsum v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,10 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.7
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gotest.tools/gotestsum v1.7.0
 )
 
 replace github.com/tendermint/tendermint v0.35.0-rc1 => github.com/AccumulateNetwork/tendermint v0.35.0-rc1.0.20211104230238-906615e51028

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
 github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
+github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/docker/cli v20.10.12+incompatible h1:lZlz0uzG+GH+c0plStMUdF/qk3ppmgnswpR5EbqzVGA=
 github.com/docker/cli v20.10.12+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -429,6 +431,8 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/trillian v1.3.11/go.mod h1:0tPraVHrSDkA3BO6vKX67zgLXs6SsOAbHEivX+9mPgw=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -536,6 +540,8 @@ github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
@@ -1271,6 +1277,7 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1521,7 +1528,12 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools/gotestsum v1.7.0 h1:RwpqwwFKBAa2h+F6pMEGpE707Edld0etUD3GhqqhDNc=
+gotest.tools/gotestsum v1.7.0/go.mod h1:V1m4Jw3eBerhI/A6qCxUE07RnCg7ACkKj9BYcAm09V8=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/abci/e2e_statedb_test.go
+++ b/internal/abci/e2e_statedb_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
 	"github.com/AccumulateNetwork/accumulate/smt/storage/badger"
 	"github.com/AccumulateNetwork/accumulate/types/state"
 	"github.com/stretchr/testify/require"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestStateDBConsistency(t *testing.T) {
+	acctesting.SkipPlatformCI(t, "darwin", "flaky")
+
 	dir := t.TempDir()
 	db := new(badger.DB)
 	err := db.InitDB(filepath.Join(dir, "valacc.db"), nil)

--- a/internal/api/v2/e2e_test.go
+++ b/internal/api/v2/e2e_test.go
@@ -134,8 +134,8 @@ func TestValidate(t *testing.T) {
 	dataAccountUrl := adiName + "/dataAccount"
 	t.Run("Create Data Account", func(t *testing.T) {
 		executeTx(t, japi, "create-data-account", true, execParams{
-			Sponsor: adiName,
-			Key:     adiKey,
+			Origin: adiName,
+			Key:    adiKey,
 			Payload: &CreateDataAccount{
 				Url: dataAccountUrl,
 			},
@@ -153,8 +153,8 @@ func TestValidate(t *testing.T) {
 			PublicKey: adiKey,
 		})
 		executeTx(t, japi, "create-key-page", true, execParams{
-			Sponsor: adiName,
-			Key:     adiKey,
+			Origin: adiName,
+			Key:    adiKey,
 			Payload: &CreateKeyPage{
 				Url:  keyPageUrl,
 				Keys: keys,
@@ -172,8 +172,8 @@ func TestValidate(t *testing.T) {
 		pageChainId := types.Bytes(pageUrl.ResourceChain()).AsBytes32()
 		page = append(page, pageChainId)
 		executeTx(t, japi, "create-key-book", true, execParams{
-			Sponsor: adiName,
-			Key:     adiKey,
+			Origin: adiName,
+			Key:    adiKey,
 			Payload: &CreateKeyBook{
 				Url:   keyBookUrl,
 				Pages: page,
@@ -188,8 +188,8 @@ func TestValidate(t *testing.T) {
 	tokenAccountUrl := adiName + "/account"
 	t.Run("Create Token Account", func(t *testing.T) {
 		executeTx(t, japi, "create-token-account", true, execParams{
-			Sponsor: adiName,
-			Key:     adiKey,
+			Origin: adiName,
+			Key:    adiKey,
 			Payload: &TokenAccountCreate{
 				Url:        tokenAccountUrl,
 				TokenUrl:   tokenUrl,

--- a/internal/api/v2/e2e_test.go
+++ b/internal/api/v2/e2e_test.go
@@ -5,12 +5,11 @@ import (
 	"crypto/ed25519"
 	"encoding/json"
 	"net"
-	"os"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/AccumulateNetwork/accumulate/internal/api/v2"
+	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
 	"github.com/AccumulateNetwork/accumulate/internal/testing/e2e"
 	"github.com/AccumulateNetwork/accumulate/internal/url"
 	. "github.com/AccumulateNetwork/accumulate/protocol"
@@ -23,13 +22,9 @@ import (
 )
 
 func TestEndToEnd(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		t.Skip("This test does not work well on Windows or macOS")
-	}
-
-	if os.Getenv("CI") == "true" {
-		t.Skip("This test consistently fails in CI")
-	}
+	acctesting.SkipCI(t, "flaky")
+	acctesting.SkipPlatform(t, "windows", "flaky")
+	acctesting.SkipPlatform(t, "darwin", "flaky, requires setting up localhost aliases")
 
 	baseIP := net.ParseIP("127.1.25.1")
 	suite.Run(t, e2e.NewSuite(func(s *e2e.Suite) e2e.DUT {
@@ -39,9 +34,8 @@ func TestEndToEnd(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		t.Skip("This test does not work well on Windows or macOS")
-	}
+	acctesting.SkipPlatform(t, "windows", "flaky")
+	acctesting.SkipPlatform(t, "darwin", "flaky, requires setting up localhost aliases")
 
 	daemons := startAccumulate(t, net.ParseIP("127.1.26.1"), 2, 2, 3000)
 	japi := daemons[0].Jrpc_TESTONLY()
@@ -146,7 +140,6 @@ func TestValidate(t *testing.T) {
 	})
 
 	keyPageUrl := adiName + "/page1"
-	//var pageKey ed25519.PrivateKey
 	t.Run("Create Key Page", func(t *testing.T) {
 		var keys []*KeySpecParams
 		keys = append(keys, &KeySpecParams{

--- a/internal/node/e2e_test.go
+++ b/internal/node/e2e_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
-	"runtime"
 	"testing"
 	"time"
 
@@ -31,13 +29,9 @@ import (
 )
 
 func TestEndToEnd(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		t.Skip("This test does not work well on Windows or macOS")
-	}
-
-	if os.Getenv("CI") == "true" {
-		t.Skip("This test consistently fails in CI")
-	}
+	acctesting.SkipCI(t, "flaky")
+	acctesting.SkipPlatform(t, "windows", "flaky")
+	acctesting.SkipPlatform(t, "darwin", "flaky, requires setting up localhost aliases")
 
 	suite.Run(t, e2e.NewSuite(func(s *e2e.Suite) e2e.DUT {
 
@@ -94,9 +88,8 @@ func (d *e2eDUT) WaitForTxns(txids ...[]byte) {
 }
 
 func TestSubscribeAfterClose(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		t.Skip("This test does not work well on Windows or macOS")
-	}
+	acctesting.SkipPlatform(t, "windows", "flaky")
+	acctesting.SkipPlatform(t, "darwin", "flaky")
 
 	daemon := initNodes(t, t.Name(), net.ParseIP("127.0.30.1"), 3000, 1, []string{"127.0.30.1"})[0]
 	require.NoError(t, daemon.Stop())
@@ -112,9 +105,8 @@ func TestSubscribeAfterClose(t *testing.T) {
 }
 
 func TestFaucetMultiNetwork(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		t.Skip("This test does not work well on Windows or macOS")
-	}
+	acctesting.SkipPlatform(t, "windows", "flaky")
+	acctesting.SkipPlatform(t, "darwin", "flaky")
 
 	bvc0 := initNodes(t, "BVC0", net.ParseIP("127.0.26.1"), 3000, 1, []string{"127.0.26.1", "127.0.27.1", "127.0.28.1"})
 	bvc1 := initNodes(t, "BVC1", net.ParseIP("127.0.27.1"), 3000, 1, []string{"127.0.26.1", "127.0.27.1", "127.0.28.1"})

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -17,14 +17,8 @@ import (
 )
 
 func TestNodeLifecycle(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Tendermint does not close all its open files on shutdown, which causes cleanup to fail")
-	}
-
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
-
+	acctesting.SkipLong(t)
+	
 	// Configure
 	opts := acctesting.NodeInitOptsForNetwork(acctesting.LocalBVN)
 	opts.WorkDir = t.TempDir()

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestNodeLifecycle(t *testing.T) {
 	acctesting.SkipLong(t)
-	
+
 	// Configure
 	opts := acctesting.NodeInitOptsForNetwork(acctesting.LocalBVN)
 	opts.WorkDir = t.TempDir()

--- a/internal/testing/skip.go
+++ b/internal/testing/skip.go
@@ -1,0 +1,35 @@
+package testing
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// SkipLong skips a long test when running in -short mode.
+func SkipLong(t testing.TB) {
+	if testing.Short() {
+		t.Skip("Skipping test: running with -short")
+	}
+}
+
+// SkipCI skips a test when running in CI.
+func SkipCI(t testing.TB, reason string) {
+	if os.Getenv("CI") == "true" {
+		t.Skipf("Skipping test: running CI: %s", reason)
+	}
+}
+
+// SkipPlatform skips a test when on a specific GOOS.
+func SkipPlatform(t testing.TB, goos, reason string) {
+	if runtime.GOOS == goos {
+		t.Skipf("Skipping test: running on %s: %s", goos, reason)
+	}
+}
+
+// SkipPlatformCI skips a test when running in CI on a specific GOOS.
+func SkipPlatformCI(t testing.TB, goos, reason string) {
+	if runtime.GOOS == goos && os.Getenv("CI") == "true" {
+		t.Skipf("Skipping test: running CI on %s: %s", goos, reason)
+	}
+}

--- a/smt/storage/badger/db.go
+++ b/smt/storage/badger/db.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/AccumulateNetwork/accumulate/smt/storage"
-	"github.com/AccumulateNetwork/accumulate/types"
 	"github.com/dgraph-io/badger"
 )
 
@@ -21,9 +21,10 @@ import (
 var TruncateBadger = false
 
 type DB struct {
-	DBOpen   types.AtomicBool
-	DBHome   string
+	ready    bool
+	readyMu  *sync.RWMutex
 	badgerDB *badger.DB
+	logger   storage.Logger
 }
 
 var _ storage.KeyValueDB = (*DB)(nil)
@@ -31,7 +32,13 @@ var _ storage.KeyValueDB = (*DB)(nil)
 // Close
 // Close the underlying database
 func (d *DB) Close() error {
-	defer d.DBOpen.Store(false)
+	if l, err := d.lock(true); err != nil {
+		return err
+	} else {
+		defer l.Unlock()
+	}
+
+	d.ready = false
 	return d.badgerDB.Close()
 }
 
@@ -45,37 +52,59 @@ func (d *DB) InitDB(filepath string, logger storage.Logger) error {
 	if err != nil {
 		return errors.New("failed to create home directory")
 	}
-	d.DBHome = filepath
 
-	// Open Badger
-	opts := badger.DefaultOptions(d.DBHome)
+	opts := badger.DefaultOptions(filepath)
 
+	// Truncate corrupted data
 	if TruncateBadger {
 		opts = opts.WithTruncate(true)
 	}
 
+	// Add logger
 	if logger != nil {
 		opts = opts.WithLogger(badgerLogger{logger})
 	}
+
+	// Open Badger
 	d.badgerDB, err = badger.Open(opts)
-	if err != nil { // Panic if we can't open Badger
+	if err != nil {
 		return err
 	}
-	d.DBOpen.Store(true)
+
+	d.logger = logger
+	d.ready = true
+	d.readyMu = new(sync.RWMutex)
+
 	return nil
 }
 
-func (d *DB) Ready() bool {
-	return d.DBOpen.Load()
+// lock acquires a lock on the ready mutex and checks for readiness. This
+// prevents race conditions between Get/Put and Close, which can cause panics.
+func (d *DB) lock(closing bool) (sync.Locker, error) {
+	var l sync.Locker = d.readyMu
+	if !closing {
+		l = d.readyMu.RLocker()
+	}
+
+	l.Lock()
+	if !d.ready {
+		l.Unlock()
+		return nil, storage.ErrNotOpen
+	}
+
+	return l, nil
 }
 
 // Get
 // Look in the given bucket, and return the key found.  Returns nil if no value
 // is found for the given key
 func (d *DB) Get(key storage.Key) (value []byte, err error) {
-	if !d.Ready() {
-		return nil, errors.New("database is not open")
+	if l, err := d.lock(false); err != nil {
+		return nil, err
+	} else {
+		defer l.Unlock()
 	}
+
 	err = d.badgerDB.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(key[:])
 		if err != nil {
@@ -105,9 +134,12 @@ func (d *DB) Get(key storage.Key) (value []byte, err error) {
 // Put a key/value in the database.  We return an error if there was a problem
 // writing the key/value pair to the database.
 func (d *DB) Put(key storage.Key, value []byte) error {
-	if !d.Ready() {
-		return errors.New("database is not open")
+	if l, err := d.lock(false); err != nil {
+		return err
+	} else {
+		defer l.Unlock()
 	}
+
 	// Update the key/value in the database
 	err := d.badgerDB.Update(func(txn *badger.Txn) error {
 		err := txn.Set(key[:], value)

--- a/smt/storage/keyvaluedb.go
+++ b/smt/storage/keyvaluedb.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 )
 
-// ErrNotFound is returned by KeyValueDB.Get if the key is not found
+// ErrNotFound is returned by KeyValueDB.Get if the key is not found.
 var ErrNotFound = errors.New("not found")
+
+// ErrNotOpen is returned by KeyValueDB.Get, .Put, and .Close if the database is
+// not open.
+var ErrNotOpen = errors.New("not open")
 
 type KeyValueDB interface {
 	Close() error                                // Returns an error if the close fails
-	Ready() bool                                 // Returns true if the database is ready for reads/writes
 	InitDB(filepath string, logger Logger) error // Sets up the database, returns error if it fails
 	Get(key Key) (value []byte, err error)       // Get key from database, returns ErrNotFound if the key is not found
 	Put(key Key, value []byte) error             // Put the value in the database, throws an error if fails

--- a/smt/storage/memory/db.go
+++ b/smt/storage/memory/db.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"sort"
 	"sync"
 
@@ -35,7 +34,7 @@ func (m *DB) Ready() bool {
 func (m *DB) EndBatch(txCache map[storage.Key][]byte) error {
 	m.mutex.Lock()
 	if !m.Ready() {
-		return errors.New("database is not open")
+		return storage.ErrNotOpen
 	}
 	defer m.mutex.Unlock()
 	for k, v := range txCache {
@@ -131,7 +130,7 @@ func (m *DB) Get(key storage.Key) (value []byte, err error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	if !m.Ready() {
-		return nil, errors.New("database is not open")
+		return nil, storage.ErrNotOpen
 	}
 
 	v, ok := m.entries[key]
@@ -147,7 +146,7 @@ func (m *DB) Put(key storage.Key, value []byte) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	if !m.Ready() {
-		return errors.New("database is not open")
+		return storage.ErrNotOpen
 	}
 	m.entries[key] = value
 	return nil

--- a/tools.go
+++ b/tools.go
@@ -8,4 +8,5 @@ import (
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/rinchsan/gosimports/cmd/gosimports"
 	_ "golang.org/x/tools/cmd/goimports"
+	_ "gotest.tools/gotestsum"
 )

--- a/types/api/APIRequests_test.go
+++ b/types/api/APIRequests_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -200,9 +199,7 @@ func TestAPIRequest_TokenTx(t *testing.T) {
 	adiUrl := "greentractor"
 
 	message, err := createTokenTx(adiUrl)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	params := createRequest(t, adiUrl, &kp, message)
 
 	validate, err := protocol.NewValidator()
@@ -210,20 +207,15 @@ func TestAPIRequest_TokenTx(t *testing.T) {
 
 	req := &APIRequestRaw{}
 	// unmarshal req
-	if err = json.Unmarshal(params, &req); err != nil {
-		t.Fatal(err)
-	}
+	err = json.Unmarshal(params, &req)
+	require.NoError(t, err)
 
 	// validate request
-	if err = validate.Struct(req); err != nil {
-		t.Fatal(err)
-	}
+	err = validate.Struct(req)
+	require.NoError(t, err)
 
-	//tx, err := json.MarshalIndent(&req,"", "  ")
 	tx, err := json.Marshal(&req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	fmt.Printf("%s", string(tx))
+	t.Logf("%s", tx)
 }


### PR DESCRIPTION
Use `gotest.tools/gotestsum` to run tests and generate a JUnit test report file. This will improve the readability of test results in CI, and GitLab CI can use the JUnit report to populate a test results UI.