### PR TITLE
test: stop hard coding IPs

### DIFF
--- a/cmd/cli/cmd/faucet_test.go
+++ b/cmd/cli/cmd/faucet_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/AccumulateNetwork/accumulate/internal/api/v2"
 	api2 "github.com/AccumulateNetwork/accumulate/types/api"
 	"github.com/AccumulateNetwork/accumulate/types/api/response"
 	"github.com/stretchr/testify/require"
@@ -17,11 +18,18 @@ func init() {
 func testCase5_1(t *testing.T, tc *testCmd) {
 	t.Helper()
 
-	var beenFauceted []bool
+	beenFauceted := make([]bool, len(liteAccounts))
 	//test to see if things have already been fauceted...
 	for i := range liteAccounts {
-		bal, _ := testGetBalance(t, tc, liteAccounts[i])
-		beenFauceted = append(beenFauceted, bal == "1000000000")
+		bal, err := testGetBalance(t, tc, liteAccounts[i])
+		if err == nil {
+			beenFauceted[i] = bal == "1000000000"
+			continue
+		}
+
+		jerr := new(JsonRpcError)
+		require.ErrorAs(t, err, &jerr)
+		require.Equal(t, api.ErrCodeNotFound, int(jerr.Err.Code))
 	}
 
 	var results []string

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -27,7 +27,7 @@ var currentUser = func() *user.User {
 	return usr
 }()
 
-var DidError bool
+var DidError error
 
 func InitRootCmd(database db.DB) *cobra.Command {
 	Db = database
@@ -67,7 +67,7 @@ func InitRootCmd(database db.DB) *cobra.Command {
 	cmd.AddCommand(faucetCmd)
 
 	cmd.PersistentPostRun = func(*cobra.Command, []string) {
-		if DidError {
+		if DidError != nil {
 			os.Exit(1)
 		}
 	}

--- a/cmd/cli/cmd/util.go
+++ b/cmd/cli/cmd/util.go
@@ -353,6 +353,13 @@ func (a *ActionResponse) Print() (string, error) {
 	return "", errors.New(out)
 }
 
+type JsonRpcError struct {
+	Msg string
+	Err jsonrpc2.Error
+}
+
+func (e *JsonRpcError) Error() string { return e.Msg }
+
 func PrintJsonRpcError(err error) (string, error) {
 	var e jsonrpc2.Error
 	switch err := err.(type) {
@@ -367,20 +374,20 @@ func PrintJsonRpcError(err error) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return "", errors.New(string(out))
+		return "", &JsonRpcError{Err: e, Msg: string(out)}
 	} else {
 		var out string
 		out += fmt.Sprintf("\n\tMessage\t\t:\t%v\n", e.Message)
 		out += fmt.Sprintf("\tError Code\t:\t%v\n", e.Code)
 		out += fmt.Sprintf("\tDetail\t\t:\t%s\n", e.Data)
-		return "", errors.New(out)
+		return "", &JsonRpcError{Err: e, Msg: out}
 	}
 }
 
 func printOutput(cmd *cobra.Command, out string, err error) {
 	if err != nil {
 		cmd.PrintErrf("Error: %v\n", err)
-		DidError = true
+		DidError = err
 	} else {
 		cmd.Println(out)
 	}

--- a/internal/api/jsonrpc_test.go
+++ b/internal/api/jsonrpc_test.go
@@ -61,7 +61,7 @@ func TestJsonRpcLiteToken(t *testing.T) {
 	fmt.Println(string(output))
 
 	// now use the JSON rpc api's to get the data
-	jsonapi := NewTest(t, query)
+	jsonapi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	params := &api.APIRequestURL{URL: types.String(queryTokenUrl)}
 	gParams, err := json.Marshal(params)
@@ -189,7 +189,7 @@ func TestFaucet(t *testing.T) {
 		t.Fatalf("expecting error code that is non zero")
 	}
 
-	jsonapi := NewTest(t, query)
+	jsonapi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	res := jsonapi.Faucet(context.Background(), params)
 	require.IsType(t, (*api.APIDataResponse)(nil), res)
@@ -241,7 +241,7 @@ func TestTransactionHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	jsonapi := NewTest(t, query)
+	jsonapi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	res := jsonapi.Faucet(context.Background(), params)
 	data, err := json.Marshal(res)
@@ -302,7 +302,7 @@ func TestFaucetTransactionHistory(t *testing.T) {
 
 	daemon := startBVC(t, t.TempDir())
 	query := daemon.Query_TESTONLY()
-	jsonapi := NewTest(t, query)
+	jsonapi := NewTest(t, &daemon.Config.Accumulate.API, query)
 	res := jsonapi.Faucet(context.Background(), params)
 	if err, ok := res.(error); ok {
 		require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestMetrics(t *testing.T) {
 	dir := t.TempDir()
 	daemon := startBVC(t, dir)
 	query := daemon.Query_TESTONLY()
-	japi := NewTest(t, query)
+	japi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	req, err := json.Marshal(&protocol.MetricsRequest{Metric: "tps", Duration: time.Hour})
 	require.NoError(t, err)
@@ -357,7 +357,7 @@ func TestQueryNotFound(t *testing.T) {
 	dir := t.TempDir()
 	daemon := startBVC(t, dir)
 	query := daemon.Query_TESTONLY()
-	japi := NewTest(t, query)
+	japi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	req, err := json.Marshal(&api.APIRequestURL{URL: "acc://1cddf368ef9ba2a1ea914291e0201ebaf376130a6c05caf3/ACME"})
 	require.NoError(t, err)
@@ -376,7 +376,7 @@ func TestQueryWrongType(t *testing.T) {
 	dir := t.TempDir()
 	daemon := startBVC(t, dir)
 	query := daemon.Query_TESTONLY()
-	japi := NewTest(t, query)
+	japi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	destAddress, _, tx, err := acctesting.BuildTestSynthDepositGenTx()
 	require.NoError(t, err)
@@ -401,7 +401,7 @@ func TestGetTxId(t *testing.T) {
 	dir := t.TempDir()
 	daemon := startBVC(t, dir)
 	query := daemon.Query_TESTONLY()
-	japi := NewTest(t, query)
+	japi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	destAddress, _, tx, err := acctesting.BuildTestSynthDepositGenTx()
 	require.NoError(t, err)
@@ -432,7 +432,7 @@ func TestDirectory(t *testing.T) {
 	dir := t.TempDir()
 	daemon := startBVC(t, dir)
 	query := daemon.Query_TESTONLY()
-	japi := NewTest(t, query)
+	japi := NewTest(t, &daemon.Config.Accumulate.API, query)
 
 	_, adiKey, _ := ed25519.GenerateKey(nil)
 	dbTx := daemon.DB_TESTONLY().Begin()
@@ -476,7 +476,7 @@ func TestFaucetReplay(t *testing.T) {
 	daemon := startBVC(t, dir)
 	query := daemon.Query_TESTONLY()
 
-	jsonapi := NewTest(t, query)
+	jsonapi := NewTest(t, &daemon.Config.Accumulate.API, query)
 	res, err := jsonapi.BroadcastTx(false, gtx)
 	require.NoError(t, err)
 	require.NoError(t, acctesting.WaitForTxV1(query, res))

--- a/internal/api/utils2_test.go
+++ b/internal/api/utils2_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	cfg "github.com/AccumulateNetwork/accumulate/config"
@@ -11,23 +10,10 @@ import (
 	acmeapi "github.com/AccumulateNetwork/accumulate/types/api"
 	"github.com/AccumulateNetwork/accumulate/types/api/transactions"
 	"github.com/stretchr/testify/require"
-	tmnet "github.com/tendermint/tendermint/libs/net"
 )
 
-func GetFreePort(t *testing.T) int {
+func NewTest(t *testing.T, config *cfg.API, q *Query) *API {
 	t.Helper()
-	port, err := tmnet.GetFreePort()
-	require.NoError(t, err)
-	return port
-}
-
-func NewTest(t *testing.T, q *Query) *API {
-	t.Helper()
-	port := GetFreePort(t)
-	config := &cfg.API{
-		ListenAddress:    fmt.Sprintf("localhost:%d", port),
-		PrometheusServer: "http://18.119.26.7:9090",
-	}
 	v, err := protocol.NewValidator()
 	require.NoError(t, err)
 	return &API{config, v, q}

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -13,9 +13,10 @@ import (
 
 func startBVC(t *testing.T, dir string) *accumulated.Daemon {
 	t.Helper()
+	acctesting.SkipPlatformCI(t, "darwin", "requires setting up localhost aliases")
 
 	// Configure
-	opts := acctesting.NodeInitOptsForNetwork(acctesting.LocalBVN)
+	opts := acctesting.NodeInitOptsForLocalNetwork(t.Name(), acctesting.GetIP())
 	opts.WorkDir = dir
 	opts.Config[0].Accumulate.API.EnableSubscribeTX = true
 	require.NoError(t, node.Init(opts))

--- a/internal/api/v2/e2e_harness_test.go
+++ b/internal/api/v2/e2e_harness_test.go
@@ -32,7 +32,11 @@ import (
 
 var reAlphaNum = regexp.MustCompile("[^a-zA-Z0-9]")
 
-func startAccumulate(t *testing.T, baseIP net.IP, bvns, validators, basePort int) []*accumulated.Daemon {
+func startAccumulate(t *testing.T, ips []net.IP, bvns, validators, basePort int) []*accumulated.Daemon {
+	if len(ips) != bvns*validators {
+		panic(fmt.Errorf("want %d validators each for %d BVNs but got %d IPs", validators, bvns, len(ips)))
+	}
+
 	names := make([]string, bvns)
 	addrs := make(map[string][]string, bvns)
 	IPs := make([][]string, bvns)
@@ -45,9 +49,8 @@ func startAccumulate(t *testing.T, baseIP net.IP, bvns, validators, basePort int
 		IPs[bvn] = make([]string, validators)
 		addrs[names[bvn]] = make([]string, validators)
 		for val := 0; val < validators; val++ {
-			ip := make(net.IP, len(baseIP))
-			copy(ip, baseIP)
-			baseIP[15]++
+			ip := ips[0]
+			ips = ips[1:]
 			IPs[bvn][val] = ip.String()
 			addrs[names[bvn]][val] = fmt.Sprintf("http://%v:%d", ip, basePort)
 		}

--- a/internal/api/v2/e2e_test.go
+++ b/internal/api/v2/e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/json"
-	"net"
 	"testing"
 	"time"
 
@@ -25,20 +24,24 @@ import (
 func TestEndToEnd(t *testing.T) {
 	acctesting.SkipCI(t, "flaky")
 	acctesting.SkipPlatform(t, "windows", "flaky")
-	acctesting.SkipPlatform(t, "darwin", "flaky, requires setting up localhost aliases")
+	acctesting.SkipPlatform(t, "darwin", "flaky")
+	acctesting.SkipPlatformCI(t, "darwin", "requires setting up localhost aliases")
 
-	baseIP := net.ParseIP("127.1.25.1")
+	// Reuse the same IPs for each test
+	ips := acctesting.GetIPs(2)
+
 	suite.Run(t, e2e.NewSuite(func(s *e2e.Suite) e2e.DUT {
-		daemons := startAccumulate(t, baseIP, 1, 2, 3000)
+		daemons := startAccumulate(t, ips, 1, 2, 3000)
 		return &e2eDUT{s, daemons}
 	}))
 }
 
 func TestValidate(t *testing.T) {
 	acctesting.SkipPlatform(t, "windows", "flaky")
-	acctesting.SkipPlatform(t, "darwin", "flaky, requires setting up localhost aliases")
+	acctesting.SkipPlatform(t, "darwin", "flaky")
+	acctesting.SkipPlatformCI(t, "darwin", "requires setting up localhost aliases")
 
-	daemons := startAccumulate(t, net.ParseIP("127.1.26.1"), 2, 2, 3000)
+	daemons := startAccumulate(t, acctesting.GetIPs(4), 2, 2, 3000)
 	japi := daemons[0].Jrpc_TESTONLY()
 
 	t.Run("Not found", func(t *testing.T) {
@@ -210,9 +213,10 @@ func TestValidate(t *testing.T) {
 
 func TestTokenTransfer(t *testing.T) {
 	acctesting.SkipPlatform(t, "windows", "flaky")
-	acctesting.SkipPlatform(t, "darwin", "flaky, requires setting up localhost aliases")
+	acctesting.SkipPlatform(t, "darwin", "flaky")
+	acctesting.SkipPlatformCI(t, "darwin", "requires setting up localhost aliases")
 
-	daemons := startAccumulate(t, net.ParseIP("127.1.26.1"), 2, 2, 3000)
+	daemons := startAccumulate(t, acctesting.GetIPs(4), 2, 2, 3000)
 
 	var aliceKey ed25519.PrivateKey
 	var aliceUrl *url.URL

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -13,14 +13,13 @@ import (
 	acctesting "github.com/AccumulateNetwork/accumulate/internal/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	tmnet "github.com/tendermint/tendermint/libs/net"
 )
 
 func TestNodeLifecycle(t *testing.T) {
-	acctesting.SkipLong(t)
+	acctesting.SkipPlatformCI(t, "darwin", "requires setting up localhost aliases")
 
 	// Configure
-	opts := acctesting.NodeInitOptsForNetwork(acctesting.LocalBVN)
+	opts := acctesting.NodeInitOptsForLocalNetwork(t.Name(), acctesting.GetIP())
 	opts.WorkDir = t.TempDir()
 	require.NoError(t, node.Init(opts))
 
@@ -60,11 +59,4 @@ func TestNodeLifecycle(t *testing.T) {
 
 		assert.Failf(t, "Files are still open after the node was shut down", "%q is open", rel)
 	}
-}
-
-func getFreePort(t *testing.T) int {
-	t.Helper()
-	port, err := tmnet.GetFreePort()
-	require.NoError(t, err)
-	return port
 }

--- a/internal/node/utils_test.go
+++ b/internal/node/utils_test.go
@@ -19,7 +19,7 @@ import (
 
 var reAlphaNum = regexp.MustCompile("[^a-zA-Z0-9]")
 
-func initNodes(t *testing.T, name string, baseIP net.IP, basePort int, count int, bvnAddrs []string) []*accumulated.Daemon {
+func initNodes(t *testing.T, name string, ips []net.IP, basePort int, count int, bvnAddrs []string) []*accumulated.Daemon {
 	t.Helper()
 
 	name = reAlphaNum.ReplaceAllString(name, "-")
@@ -27,10 +27,11 @@ func initNodes(t *testing.T, name string, baseIP net.IP, basePort int, count int
 	IPs := make([]string, count)
 	config := make([]*config.Config, count)
 
-	for i := range IPs {
-		ip := make(net.IP, len(baseIP))
-		copy(ip, baseIP)
-		ip[15] += byte(i)
+	if len(ips) != count {
+		panic(fmt.Errorf("want %d validators but got %d IPs", count, len(ips)))
+	}
+
+	for i, ip := range ips {
 		IPs[i] = ip.String()
 	}
 

--- a/internal/testing/ip.go
+++ b/internal/testing/ip.go
@@ -1,0 +1,39 @@
+package testing
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"runtime"
+)
+
+func getIP() net.IP {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		panic("could not determine caller")
+	}
+	hash := sha256.Sum256([]byte(fmt.Sprintf("%s:%d", file, line)))
+	ip := net.ParseIP("127.0.0.0")
+	ip[13] = hash[0]
+	ip[14] = hash[1]
+	ip[15] = hash[2]
+	if ip[15] == 0 {
+		ip[15]++
+	}
+	return ip
+}
+
+func GetIP() net.IP {
+	return getIP()
+}
+
+func GetIPs(n int) []net.IP {
+	ip := getIP()
+	ips := make([]net.IP, n)
+	for i := range ips {
+		ips[i] = make(net.IP, len(ip))
+		copy(ips[i], ip)
+		ip[15]++
+	}
+	return ips
+}

--- a/internal/testing/node.go
+++ b/internal/testing/node.go
@@ -2,23 +2,13 @@ package testing
 
 import (
 	"io"
+	"net"
 	"time"
 
 	"github.com/AccumulateNetwork/accumulate/config"
 	"github.com/AccumulateNetwork/accumulate/internal/accumulated"
 	"github.com/AccumulateNetwork/accumulate/internal/node"
-	"github.com/AccumulateNetwork/accumulate/networks"
-	tmnet "github.com/tendermint/tendermint/libs/net"
 )
-
-var LocalBVN = &networks.Subnet{
-	Name: "Local",
-	Type: config.BlockValidator,
-	Port: 35550,
-	Nodes: []networks.Node{
-		{IP: "127.0.0.1", Type: config.Validator},
-	},
-}
 
 func DefaultConfig(net config.NetworkType, node config.NodeType, netId string) *config.Config {
 	cfg := config.Default(net, node, netId)        //
@@ -34,27 +24,13 @@ func DefaultConfig(net config.NetworkType, node config.NodeType, netId string) *
 	return cfg
 }
 
-func NodeInitOptsForNetwork(subnet *networks.Subnet) node.InitOptions {
-	listenIP := make([]string, len(subnet.Nodes))
-	remoteIP := make([]string, len(subnet.Nodes))
-	cfg := make([]*config.Config, len(subnet.Nodes))
-
-	for i, net := range subnet.Nodes {
-		listenIP[i] = "localhost"
-		remoteIP[i] = net.IP
-		cfg[i] = DefaultConfig(subnet.Type, net.Type, subnet.Name) // Configure
-	}
-
-	port, err := tmnet.GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-
+func NodeInitOptsForLocalNetwork(name string, ip net.IP) node.InitOptions {
+	// TODO Support DN, multi-BVN, multi-validator
 	return node.InitOptions{
-		Port:     port,
-		Config:   cfg,
-		RemoteIP: remoteIP,
-		ListenIP: listenIP,
+		Port:     30000,
+		Config:   []*config.Config{DefaultConfig(config.BlockValidator, config.Validator, name)},
+		RemoteIP: []string{ip.String()},
+		ListenIP: []string{ip.String()},
 	}
 }
 


### PR DESCRIPTION
Instead of hard coding IPs, test IPs are now derived from the SHA-256 hash of the file name and line number of the test.